### PR TITLE
Fixes #13

### DIFF
--- a/src/main/java/no/bekk/bekkopen/date/NorwegianDateUtil.java
+++ b/src/main/java/no/bekk/bekkopen/date/NorwegianDateUtil.java
@@ -272,7 +272,7 @@ public class NorwegianDateUtil {
 	 * @return The date represented by the given values.
 	 */
 	private static Date getDate(int day, int month, int year) {
-		Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("Europe/Berlin"), new Locale("no", "NO"));
+		Calendar cal = Calendar.getInstance();
 		cal.set(Calendar.YEAR, year);
 		cal.set(Calendar.MONTH, month);
 		cal.set(Calendar.DATE, day);


### PR DESCRIPTION
Det var noe Locale i getDate som gjorde at det på Unix som bruker en_US ikke ble laget lik dato for 1. mai i 2008 som også er Kristi Himmelfartsdag i 2008
