### PR TITLE
Should validate KID correctly when Mod11 fails

### DIFF
--- a/src/main/java/no/bekk/bekkopen/banking/KidnummerValidator.java
+++ b/src/main/java/no/bekk/bekkopen/banking/KidnummerValidator.java
@@ -56,10 +56,14 @@ public class KidnummerValidator extends StringNumberValidator implements Constra
     public static void validateChecksum(String kidnummer) {
         StringNumber k = new Kidnummer(kidnummer);
         int kMod10 = calculateMod10CheckSum(getMod10Weights(k), k);
-        int kMod11 = calculateMod11CheckSum(getMod11Weights(k), k);
-        if (kMod10 != k.getChecksumDigit() && kMod11 != k.getChecksumDigit()) {
-            throw new IllegalArgumentException(ERROR_INVALID_CHECKSUM + kidnummer);
+        if (kMod10 == k.getChecksumDigit()) {
+            return;
         }
+        int kMod11 = calculateMod11CheckSum(getMod11Weights(k), k);
+        if (kMod11 == k.getChecksumDigit()) {
+            return;
+        }
+        throw new IllegalArgumentException(ERROR_INVALID_CHECKSUM + kidnummer);
     }
 
     public void initialize(no.bekk.bekkopen.banking.annotation.Kidnummer constraintAnnotation) {

--- a/src/test/java/no/bekk/bekkopen/banking/KidnummerValidatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/banking/KidnummerValidatorTest.java
@@ -1,12 +1,11 @@
 package no.bekk.bekkopen.banking;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import no.bekk.bekkopen.NoCommonsTestCase;
 import no.bekk.bekkopen.common.StringNumberValidator;
 
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class KidnummerValidatorTest extends NoCommonsTestCase {
 
@@ -65,6 +64,13 @@ public class KidnummerValidatorTest extends NoCommonsTestCase {
 			assertMessageContains(e, StringNumberValidator.ERROR_INVALID_CHECKSUM);
 		}
 	}
+
+    @Test
+    public void testValidKidnummerMod10ButUnableToCalculateMod11() {
+        boolean result = KidnummerValidator.isValid("01290865");
+
+        assertEquals(true, result);
+    }
 
 	@Test
 	public void testIsValidMod10() {


### PR DESCRIPTION
Since the KID validation uses both Mod10 and Mod11, there are some cases where a KID number is valid (using Mod10), but the generation of Mod11 checksum fails.
When this happens a valid KID is reported as invalid.
