### PR TITLE
Fixed bug in FodselsnummerValidator.getManyFodselsnummerForDate

### DIFF
--- a/src/main/java/no/bekk/bekkopen/person/FodselsnummerValidator.java
+++ b/src/main/java/no/bekk/bekkopen/person/FodselsnummerValidator.java
@@ -19,6 +19,7 @@ public class FodselsnummerValidator extends StringNumberValidator implements Con
 	private static final String DATE_FORMAT = "ddMMyyyy";
 
 	private static final int[] K1_WEIGHTS = new int[] { 2, 5, 4, 9, 8, 1, 6, 7, 3 };
+	private static final int[] K2_WEIGHTS = new int[] { 2, 3, 4, 5, 6, 7, 2, 3, 4, 5 };
 
 	protected static final String ERROR_INVALID_DATE = "Invalid date in fødselsnummer : ";
 
@@ -94,7 +95,7 @@ public class FodselsnummerValidator extends StringNumberValidator implements Con
 	}
 
 	static int calculateSecondChecksumDigit(no.bekk.bekkopen.person.Fodselsnummer fodselsnummer) {
-		return calculateMod11CheckSum(getMod11Weights(fodselsnummer), fodselsnummer);
+		return calculateMod11CheckSum(K2_WEIGHTS, fodselsnummer);
 	}
 
     /**

--- a/src/test/java/no/bekk/bekkopen/person/FodselsnummerCalculatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/FodselsnummerCalculatorTest.java
@@ -39,7 +39,7 @@ public class FodselsnummerCalculatorTest {
 	@Test
 	public void getValidFodselsnummerForDate() {
 		List<Fodselsnummer> validOptions = FodselsnummerCalculator.getManyFodselsnummerForDate(date);
-		assertTrue("Forventet 38 fødselsnumre, men fikk " + validOptions.size(), validOptions.size() == 38);
+		assertTrue("Forventet 413 fødselsnumre, men fikk " + validOptions.size(), validOptions.size() == 413);
 	}
 
    @Test

--- a/src/test/java/no/bekk/bekkopen/person/FodselsnummerValidatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/FodselsnummerValidatorTest.java
@@ -1,5 +1,6 @@
 package no.bekk.bekkopen.person;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import no.bekk.bekkopen.NoCommonsTestCase;
@@ -116,5 +117,13 @@ public class FodselsnummerValidatorTest extends NoCommonsTestCase {
 	@Test
 	public void testGetDNumber() {
 		FodselsnummerValidator.getFodselsnummer("47086303651");
+	}
+
+	@Test
+	public void testCalculateSecondChecksumDigit() {
+		Fodselsnummer testcase = new Fodselsnummer("1234567891");
+		int correctChecksum = 1;
+		int calculatedChecksum = FodselsnummerValidator.calculateSecondChecksumDigit(testcase);
+		assertEquals(calculatedChecksum, correctChecksum);
 	}
 }


### PR DESCRIPTION
Tried to generate all Fodselsnummer for a given date, and realized that the amount generated was way too low. This also affects the randomness og the random Fodselsnummer generator (getFodselsnummerForDate) as it uses the same function to generate all Fodselsnummer.

I need this for a project, but don't really want to vendor the code. A quick merge of the fix would be appreciated, if possible.