### PR TITLE
Fikset feil i d-nummergenerering

### DIFF
--- a/src/main/java/no/bekk/bekkopen/person/FodselsnummerCalculator.java
+++ b/src/main/java/no/bekk/bekkopen/person/FodselsnummerCalculator.java
@@ -46,7 +46,7 @@ public class FodselsnummerCalculator {
 		String centuryString = getCentury(date);
 		String dateString = df.format(date);
 		dateString = new StringBuilder()
-				.append(dateString.charAt(0) + 4)
+				.append(Character.toChars(dateString.charAt(0) + 4)[0])
 				.append(dateString.substring(1))
 				.toString();
 		return generateFodselsnummerForDate(dateString, centuryString);

--- a/src/test/java/no/bekk/bekkopen/person/FodselsnummerCalculatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/FodselsnummerCalculatorTest.java
@@ -42,33 +42,43 @@ public class FodselsnummerCalculatorTest {
 		assertTrue("Forventet 413 fødselsnumre, men fikk " + validOptions.size(), validOptions.size() == 413);
 	}
 
-   @Test
-   public void testThatAllGeneratedNumbersAreValid() {
-      for(Fodselsnummer fnr : FodselsnummerCalculator.getManyFodselsnummerForDate(date)) {
-         assertTrue("Ugyldig fødselsnummer: " + fnr, FodselsnummerValidator.isValid(fnr.toString()));
-      }
-   }
+	@Test
+	public void testThatAllGeneratedNumbersAreValid() {
+		for(Fodselsnummer fnr : FodselsnummerCalculator.getManyFodselsnummerForDate(date)) {
+			assertTrue("Ugyldig fødselsnummer: " + fnr, FodselsnummerValidator.isValid(fnr.toString()));
+		}
+	}
 
-   @Test
-   public void testThatAllGeneratedNumbersAreNotDNumbers() {
+	@Test
+	public void testThatAllGeneratedNumbersAreNotDNumbers() {
 		for(Fodselsnummer fnr : FodselsnummerCalculator.getManyFodselsnummerForDate(date)) {
 			assertTrue("Ugyldig fødselsnummer: " + fnr, Fodselsnummer.isDNumber(fnr.toString()) != true);
 		}
-   }
+	}
 
-   @Test
-   public void testThatAllGeneratedDNumbersAreValid() {
+	@Test
+	public void testThatAtLeastOneFodselsnummerIsGenerated() {
+		assertTrue(FodselsnummerCalculator.getManyFodselsnummerForDate(date).size() >= 1);
+	}
+
+	@Test
+	public void testThatAtLeastOneDNumberIsGenerated() {
+		assertTrue(FodselsnummerCalculator.getManyDNumberFodselsnummerForDate(date).size() >= 1);
+	}
+
+	@Test
+	public void testThatAllGeneratedDNumbersAreValid() {
 		for(Fodselsnummer dnr : FodselsnummerCalculator.getManyDNumberFodselsnummerForDate(date)) {
 			assertTrue("Ugyldig D-nummer: " + dnr, FodselsnummerValidator.isValid(dnr.toString()));
 		}
-   }
+	}
 
-   @Test
-   public void testThatAllGeneratedDNumbersAreDNumbers() {
-	   for(Fodselsnummer dnr : FodselsnummerCalculator.getManyDNumberFodselsnummerForDate(date)) {
-		   assertTrue("Ugyldig D-nummer: " + dnr, Fodselsnummer.isDNumber(dnr.toString()) == true);
-	   }
-   }
+	@Test
+	public void testThatAllGeneratedDNumbersAreDNumbers() {
+		for(Fodselsnummer dnr : FodselsnummerCalculator.getManyDNumberFodselsnummerForDate(date)) {
+			assertTrue("Ugyldig D-nummer: " + dnr, Fodselsnummer.isDNumber(dnr.toString()) == true);
+		}
+	}
 
 	@Test
 	public void testInvalidDateTooEarly() throws ParseException {


### PR DESCRIPTION
Fikser kode fra #27. En typekonverteringsfeil gjorde at det genererte nummeret ble på 12 sifre. Det resulterer i en tom liste, men siden det ikke testes om listen er tom var alle testene grønne.