### PR TITLE
Validate KID number with - as checksum (mod11)

### DIFF
--- a/src/main/java/no/bekk/bekkopen/banking/Kidnummer.java
+++ b/src/main/java/no/bekk/bekkopen/banking/Kidnummer.java
@@ -42,7 +42,10 @@ public class Kidnummer extends StringNumber {
     }
     
     /**
-     * Return a valid mod10 Kidnummer by adding checksum digit
+     * Return a valid mod11 Kidnummer by adding checksum digit
+     * 
+     * Se mod11Kid for more information about special checksum chars.
+     * 
      * @param baseNumber input number, digits only
      * @return Kidnummer
      */
@@ -53,6 +56,20 @@ public class Kidnummer extends StringNumber {
     /**
      * Create a valid KID numer of the wanted length, using MOD11.
      * Input is padded with leading zeros to reach wanted target length
+     * 
+     * Be aware that mod11 checksum generation for KID allows the remainder to be 1
+     * and returns a checksum of `-` in stead of 10.
+     * 
+     * However, many frontend validation in banks, for instance, can't cope with this case and the use 
+     * of KID numbers with a `-` is strongly discouraged. With this in mind we can argue
+     * that you should eiter use mod10 as KID-checksum algorithm. Or if 
+     * NoCommons returns a KID with `-` as checksum, you should use som kind
+     * of system for your self to use another baseNumber.
+     * 
+     * In addition, many users don't understand that `-` is infact part of the KID.
+     * 
+     * NoCommons will validate a KID with `-` as valid.
+     * 
      * @param baseNumber base number to calculate checksum digit for
      * @param targetLength wanted length, 0-padded. Between 2-25
      * @return Kidnummer
@@ -62,6 +79,6 @@ public class Kidnummer extends StringNumber {
             throw new IllegalArgumentException("baseNumber too long");
         String padded = String.format("%0" + (targetLength-1) + "d", new BigInteger(baseNumber));
         Kidnummer k = new Kidnummer(padded + "0");
-        return KidnummerValidator.getKidnummer(padded + calculateMod11CheckSum(getMod11Weights(k), k));
+        return KidnummerValidator.getKidnummer(padded + calculateMod11CheckSumAllowDash(getMod11Weights(k), k));
     }
 }

--- a/src/main/java/no/bekk/bekkopen/banking/KidnummerValidator.java
+++ b/src/main/java/no/bekk/bekkopen/banking/KidnummerValidator.java
@@ -10,7 +10,7 @@ import static no.bekk.bekkopen.common.Checksums.*;
 
 public class KidnummerValidator extends StringNumberValidator implements ConstraintValidator<no.bekk.bekkopen.banking.annotation.Kidnummer, String> {
 
-    public static final String ERROR_LENGTH = "A Kidnummer is between 2 and 25 digits";
+    public static final String ERROR_LENGTH = "A Kidnummer is between 3(+1) and 25 digits";
 
     private KidnummerValidator() {
         super();
@@ -45,8 +45,8 @@ public class KidnummerValidator extends StringNumberValidator implements Constra
     }
 
     static void validateSyntax(String kidnummer) {
-        validateAllDigits(kidnummer);
-        validateLengthInRange(kidnummer, 2, 25);
+        validateAllDigits(kidnummer.replace("-", ""));
+        validateLengthInRange(kidnummer, 4, 25);
     }
 
     private static void validateLengthInRange(String kidnummer, int i, int j) {
@@ -61,8 +61,8 @@ public class KidnummerValidator extends StringNumberValidator implements Constra
         if (kMod10 == k.getChecksumDigit()) {
             return;
         }
-        int kMod11 = calculateMod11CheckSum(getMod11Weights(k), k);
-        if (kMod11 == k.getChecksumDigit()) {
+        String kMod11 = calculateMod11CheckSumAllowDash(getMod11Weights(k), k);
+        if ("-".equals(kMod11) || Integer.parseInt(kMod11) == k.getChecksumDigit()) {
             return;
         }
         throw new IllegalArgumentException(ERROR_INVALID_CHECKSUM + kidnummer);
@@ -72,7 +72,7 @@ public class KidnummerValidator extends StringNumberValidator implements Constra
     }
 
     public boolean isValid(String kidnummer, ConstraintValidatorContext context) {
-        if(kidnummer == null){
+        if (kidnummer == null) {
             return true;
         }
 

--- a/src/main/java/no/bekk/bekkopen/common/Checksums.java
+++ b/src/main/java/no/bekk/bekkopen/common/Checksums.java
@@ -7,6 +7,9 @@ public class Checksums {
     /**
      * Calculate the check sum for the given weights and number.
      *
+     * Does not allow the remainder to be 1 so that checksum should be 10
+     * and throws an IllegalArgumentException if that should be the case.
+     * 
      * @param weights The weights
      * @param number  The number
      * @return The checksum
@@ -17,6 +20,23 @@ public class Checksums {
           throw new IllegalArgumentException(ERROR_INVALID_CHECKSUM + number);
        }
        return c == 0 ? 0 : 11 - c;
+    }
+    
+    /**
+     * Calculate the check sum for the given weights and number.
+     * 
+     * Allow checksum to be `-`.
+     *
+     * @param weights The weights
+     * @param number  The number
+     * @return The checksum
+     */
+    public static String calculateMod11CheckSumAllowDash(int[] weights, StringNumber number) {
+       int c = calculateChecksum(weights, number, false) % 11;
+       if (c == 1) {
+          return "-";
+       }
+       return String.valueOf((c == 0 ? 0 : 11 - c));
     }
  
     /**

--- a/src/test/java/no/bekk/bekkopen/banking/KidnummerValidatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/banking/KidnummerValidatorTest.java
@@ -2,7 +2,6 @@ package no.bekk.bekkopen.banking;
 
 import no.bekk.bekkopen.NoCommonsTestCase;
 import no.bekk.bekkopen.common.StringNumberValidator;
-
 import org.junit.Test;
 
 import static no.bekk.bekkopen.common.Checksums.ERROR_INVALID_CHECKSUM;
@@ -10,13 +9,14 @@ import static org.junit.Assert.*;
 
 public class KidnummerValidatorTest extends NoCommonsTestCase {
 
-	private static final String KIDNUMMER_VALID_MOD10 = "2345676";
+    private static final String KIDNUMMER_VALID_MOD10 = "2345676";
 	private static final String KIDNUMMER_VALID_MOD11 = "12345678903";
 	private static final String KIDNUMMER_INVALID_CHECKSUM = "2345674";
-	private static final String KIDNUMMER_INVALID_LENGTH_SHORT = "1";
+	private static final String KIDNUMMER_INVALID_LENGTH_SHORT = "122";
 	private static final String KIDNUMMER_INVALID_LENGTH_LONG = "12345678901234567890123456";
+    private static final String KIDNUMMER_VALID_WITH_DASH = "1000005-";
 
-	@Test
+    @Test
 	public void testInvalidKidnummer() {
 		try {
 			KidnummerValidator.validateSyntax("");
@@ -87,5 +87,10 @@ public class KidnummerValidatorTest extends NoCommonsTestCase {
 	public void testIsInvalid() {
 		assertFalse(KidnummerValidator.isValid(KIDNUMMER_INVALID_CHECKSUM));
 	}
+
+    @Test
+    public void testKidWithDash() {
+        assertTrue(KidnummerValidator.isValid(KIDNUMMER_VALID_WITH_DASH));
+    }
 
 }


### PR DESCRIPTION
mod11 is allowed as KID checksum. And if the remainder is 1 then
checksum is 10. This is not ok, så what is done is return checksum as -

Added som dokumentation to show that this is allowed but discouraged
and use of these KID-numbers must be evaluated by the developer using NoCommons.

If you do some googleing you will find many implementations that
simply ignores this case. DnB for instance does not allow payment with this kind of KID.

Anyway, we can validate them as valid.

Futher reading:
https://www.sismo.no/no/pub/sporsmalOgSvar/Generelle%20s&s/kid-feil

https://www.nets.eu/no-nb/PublishingImages/Lists/Accordion%20%20OCR%20giro/AllItems/OCR%20giro%20Brukerh%C3%A5ndbok.pdf

2.2 KID (kundeidentifikasjon)
KID fra OCR giroen benyttes for å identifisere innbetalingen, slik at reskontrooppdateringen
blir korrekt. Lengden på KID kan være minimum 3 + kontrollsiffer og maksimum 25 siffer
inkludert kontrollsiffer og må være utregnet i modulus 10 eller modulus 11. Det anbefales at
KID-lengden er kortest mulig for å gjøre betalingen enklest mulig for betaler.
Utregningsalgoritmen for modulus 10 og 11 er beskrevet i systemspesifikasjonen for OCRformatet.
Ved bruk av modulus 11 vil det kunne bli ”–” (bindestrek) som modulustegn. Dette kan skape
misforståelse ved bruk av for eksempel Telegiro. Brukes modulus 10 unngås dette.