### PR TITLE
Fiks bygging med Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,7 @@
-script: mvn -v && mvn -q clean test -Dsurefire-use-file=false
+dist: xenial
+language: java
+jdk:
+  - openjdk8
+  - openjdk11
+script:
+  - mvn -v && mvn -q clean test -Dsurefire-use-file=false

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,24 @@
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>
-		
+
+		<!-- JAXB -->
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>${jaxb-api.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-impl</artifactId>
+			<version>${jaxb-api.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-core</artifactId>
+			<version>${jaxb-api.version}</version>
+		</dependency>
+
 		<!-- Test -->
 		<dependency>
 			<groupId>junit</groupId>
@@ -132,8 +149,25 @@
         </dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.jcabi</groupId>
+				<artifactId>jcabi-maven-plugin</artifactId>
+				<dependencies>
+					<dependency>
+						<groupId>javax.xml.bind</groupId>
+						<artifactId>jaxb-api</artifactId>
+						<version>${jaxb-api.version}</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+		</plugins>
+	</build>
+
 	<properties>
 		<!-- Dependency version -->
 		<junit.version>4.12</junit.version>
+		<jaxb-api.version>2.3.0</jaxb-api.version>
 	</properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,17 @@
 					</dependency>
 				</dependencies>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestEntries>
+							<Automatic-Module-Name>no.bekk.nocommons</Automatic-Module-Name>
+						</manifestEntries>
+					</archive>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Denne PR'en sørger for å kjøre bygg på en fast Ubuntu-distribusjon (`xenial`), i tillegg kjøres bygg både mot `openjdk8` og `openjdk11`.

JAXB-dependencies er introdusert for å unngå byggefeil med Java 9+.