### PR TITLE
Fix spelling in error message

### DIFF
--- a/src/main/java/no/bekk/bekkopen/org/annotation/Organisasjonsnummer.java
+++ b/src/main/java/no/bekk/bekkopen/org/annotation/Organisasjonsnummer.java
@@ -17,7 +17,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Constraint(validatedBy = OrganisasjonsnummerValidator.class)
 public @interface Organisasjonsnummer {
 
-    String message() default "Invalid organisassjonsnummer";
+    String message() default "Invalid organisasjonsnummer";
 
     Class<?>[] groups() default {};
 


### PR DESCRIPTION
Fix a spelling mistake in the error message in the `Organisasjonsnummer` annotation