### PR TITLE
Støtt syntetiske fnr og dnr for folkeregisteret test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.jcabi</groupId>
         <artifactId>parent</artifactId>
-        <version>0.49.2</version>
+        <version>0.50.5</version>
     </parent>
 
 	<scm>
@@ -141,12 +141,6 @@
 			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <version>4.3.1.Final</version>
-            <scope>test</scope>
-        </dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/no/bekk/bekkopen/person/Fodselsnummer.java
+++ b/src/main/java/no/bekk/bekkopen/person/Fodselsnummer.java
@@ -21,7 +21,7 @@ public class Fodselsnummer extends StringNumber {
 	 * @return A String containing the date and month of birth.
 	 */
 	public String getDateAndMonth() {
-		return parseDNumber(getValue()).substring(0, 4);
+		return parseSynthenticNumber(parseDNumber(getValue())).substring(0, 4);
 	}
 
 	/**
@@ -31,7 +31,7 @@ public class Fodselsnummer extends StringNumber {
 	 * @return A String containing the date of birth
 	 */
 	public String getDayInMonth() {
-		return parseDNumber(getValue()).substring(0, 2);
+		return parseSynthenticNumber(parseDNumber(getValue())).substring(0, 2);
 	}
 
 	/**
@@ -41,7 +41,7 @@ public class Fodselsnummer extends StringNumber {
 	 * @return A String containing the date of birth
 	 */
 	public String getMonth() {
-		return parseDNumber(getValue()).substring(2, 4);
+		return parseSynthenticNumber(parseDNumber(getValue())).substring(2, 4);
 	}
 
 	/**
@@ -86,7 +86,7 @@ public class Fodselsnummer extends StringNumber {
 	 * @return A String containing the date and month of birth.
 	 */
 	public String getDateOfBirth() {
-		return parseDNumber(getValue()).substring(0, 6);
+		return parseSynthenticNumber(parseDNumber(getValue())).substring(0, 6);
 	}
 
 	/**
@@ -155,10 +155,18 @@ public class Fodselsnummer extends StringNumber {
 		return !isMale();
 	}
 
-	static boolean isDNumber(String fodselsnummer) {
+  static String parseSynthenticNumber(String fodselsnummer) {
+    if (!isSynthetic(fodselsnummer)) {
+      return fodselsnummer;
+    } else {
+      return fodselsnummer.substring(0, 2) + (getThirdDigit(fodselsnummer) - 8) + fodselsnummer.substring(3);
+    }
+  }
+
+  static boolean isSynthetic(String fodselsnummer) {
 		try {
-			int firstDigit = getFirstDigit(fodselsnummer);
-			if (firstDigit > 3 && firstDigit < 8) {
+			int thirdDigit = getThirdDigit(fodselsnummer);
+			if (thirdDigit == 8 || thirdDigit == 9) {
 				return true;
 			}
 		} catch (IllegalArgumentException e) {
@@ -166,6 +174,18 @@ public class Fodselsnummer extends StringNumber {
 		}
 		return false;
 	}
+
+  static boolean isDNumber(String fodselsnummer) {
+    try {
+      int firstDigit = getFirstDigit(fodselsnummer);
+      if (firstDigit > 3 && firstDigit < 8) {
+        return true;
+      }
+    } catch (IllegalArgumentException e) {
+      // ignore
+    }
+    return false;
+  }
 
 	static String parseDNumber(String fodselsnummer) {
 		if (!isDNumber(fodselsnummer)) {
@@ -177,6 +197,10 @@ public class Fodselsnummer extends StringNumber {
 
 	private static int getFirstDigit(String fodselsnummer) {
 		return Integer.parseInt(fodselsnummer.substring(0, 1));
+	}
+
+	private static int getThirdDigit(String fodselsnummer) {
+		return Integer.parseInt(fodselsnummer.substring(2, 3));
 	}
 
 	public KJONN getKjonn() {

--- a/src/main/java/no/bekk/bekkopen/person/FodselsnummerCalculator.java
+++ b/src/main/java/no/bekk/bekkopen/person/FodselsnummerCalculator.java
@@ -45,10 +45,49 @@ public class FodselsnummerCalculator {
 		DateFormat df = new SimpleDateFormat("ddMMyy");
 		String centuryString = getCentury(date);
 		String dateString = df.format(date);
-		dateString = new StringBuilder()
-				.append(Character.toChars(dateString.charAt(0) + 4)[0])
-				.append(dateString.substring(1))
-				.toString();
+		dateString = Character.toChars(dateString.charAt(0) + 4)[0] +
+      dateString.substring(1);
+		return generateFodselsnummerForDate(dateString, centuryString);
+	}
+
+	/**
+	 * Returns a List with with VALID DNumber Fodselsnummer instances for a given Date.
+	 *
+	 * @param date The Date instance
+	 * @return A List with Fodelsnummer instances
+	 */
+
+	public static List<Fodselsnummer> getManySynteticFodselsnummerForDate(Date date) {
+		if (date == null) {
+			throw new IllegalArgumentException();
+		}
+		DateFormat df = new SimpleDateFormat("ddMMyy");
+		String centuryString = getCentury(date);
+		String dateString = df.format(date);
+		dateString = dateString.substring(0, 2) +
+      Character.toChars(dateString.charAt(2) + 8)[0] +
+      dateString.substring(3);
+		return generateFodselsnummerForDate(dateString, centuryString);
+	}
+
+	/**
+	 * Returns a List with with VALID DNumber Fodselsnummer instances for a given Date.
+	 *
+	 * @param date The Date instance
+	 * @return A List with Fodelsnummer instances
+	 */
+
+	public static List<Fodselsnummer> getManySynteticDNumberFodselsnummerForDate(Date date) {
+		if (date == null) {
+			throw new IllegalArgumentException();
+		}
+		DateFormat df = new SimpleDateFormat("ddMMyy");
+		String centuryString = getCentury(date);
+		String dateString = df.format(date);
+		dateString = Character.toChars(dateString.charAt(0) + 4)[0] +
+      dateString.substring(1, 2) +
+      Character.toChars(dateString.charAt(2) + 8)[0] +
+      dateString.substring(3);
 		return generateFodselsnummerForDate(dateString, centuryString);
 	}
 

--- a/src/main/java/no/bekk/bekkopen/person/FodselsnummerValidator.java
+++ b/src/main/java/no/bekk/bekkopen/person/FodselsnummerValidator.java
@@ -14,6 +14,14 @@ import static no.bekk.bekkopen.common.Checksums.calculateMod11CheckSum;
 /**
  * Provides methods that validates if a Fodselsnummer is valid with respect to
  * syntax, Individnummer, Date and checksum digits.
+ *
+ * This validator also validates DNummer as valid.
+ * Birth date is modified by adding 4 on the first digit
+ *
+ * The Norwegian registry Det Norske Folkeregister has decided
+ * that it will create syntetic ssn for its testpopulation.
+ * This validator will can now validate true for Fodselsnummer that has month +80
+ * for synthetic fnr/dnr
  */
 public class FodselsnummerValidator extends StringNumberValidator implements ConstraintValidator<no.bekk.bekkopen.person.annotation.Fodselsnummer, String> {
 
@@ -28,9 +36,16 @@ public class FodselsnummerValidator extends StringNumberValidator implements Con
 
 	protected static final String ERROR_INVALID_INDIVIDNUMMER = "Invalid individnummer in fødselsnummer : ";
 
+  /**
+   * Truthy validation of synthetic fnr/dnr is false. You are adviced to
+   * set til value to false in test environments where you expect
+   * syntetic fnr/dnr to appair.
+   */
+	public static boolean FAIL_ON_SYNTHETIC_NUMBER = true;
+
 	/**
 	 * Returns an object that represents a Fodselsnummer.
-	 * 
+	 *
 	 * @param fodselsnummer
 	 *            A String containing a Fodselsnummer
 	 * @return A Fodselsnummer instance
@@ -42,12 +57,19 @@ public class FodselsnummerValidator extends StringNumberValidator implements Con
 		validateIndividnummer(fodselsnummer);
 		validateDate(fodselsnummer);
 		validateChecksums(fodselsnummer);
+		validateSynthetic(fodselsnummer);
 		return new no.bekk.bekkopen.person.Fodselsnummer(fodselsnummer);
 	}
 
-	/**
+  private static void validateSynthetic(String fodselsnummer) {
+    if (Fodselsnummer.isSynthetic(fodselsnummer) && FAIL_ON_SYNTHETIC_NUMBER) {
+      throw new IllegalArgumentException("Syntetic fødselsnummer is not allowd" + fodselsnummer);
+    }
+  }
+
+  /**
 	 * Return true if the provided String is a valid Fodselsnummer.
-	 * 
+	 *
 	 * @param fodselsnummer
 	 *            A String containing a Fodselsnummer
 	 * @return true or false

--- a/src/main/java/no/bekk/bekkopen/person/FodselsnummerValidator.java
+++ b/src/main/java/no/bekk/bekkopen/person/FodselsnummerValidator.java
@@ -4,6 +4,7 @@ import no.bekk.bekkopen.common.StringNumberValidator;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
+import java.net.URL;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -42,6 +43,13 @@ public class FodselsnummerValidator extends StringNumberValidator implements Con
    * syntetic fnr/dnr to appair.
    */
 	public static boolean ALLOW_SYNTHETIC_NUMBERS = false;
+
+  static {
+    final URL flag = FodselsnummerValidator.class.getResource("/no.bekk.bekkopen.person.allow_synthetic_numbers.flag");
+    if (flag != null) {
+      ALLOW_SYNTHETIC_NUMBERS = true;
+    }
+  }
 
 	/**
 	 * Returns an object that represents a Fodselsnummer.

--- a/src/main/java/no/bekk/bekkopen/person/FodselsnummerValidator.java
+++ b/src/main/java/no/bekk/bekkopen/person/FodselsnummerValidator.java
@@ -37,11 +37,11 @@ public class FodselsnummerValidator extends StringNumberValidator implements Con
 	protected static final String ERROR_INVALID_INDIVIDNUMMER = "Invalid individnummer in fødselsnummer : ";
 
   /**
-   * Truthy validation of synthetic fnr/dnr is false. You are adviced to
-   * set til value to false in test environments where you expect
+   * Truthy validation of synthetic fnr/dnr is true. You are adviced to
+   * set til value to true in test environments where you expect
    * syntetic fnr/dnr to appair.
    */
-	public static boolean FAIL_ON_SYNTHETIC_NUMBER = true;
+	public static boolean ALLOW_SYNTHETIC_NUMBERS = false;
 
 	/**
 	 * Returns an object that represents a Fodselsnummer.
@@ -62,7 +62,7 @@ public class FodselsnummerValidator extends StringNumberValidator implements Con
 	}
 
   private static void validateSynthetic(String fodselsnummer) {
-    if (Fodselsnummer.isSynthetic(fodselsnummer) && FAIL_ON_SYNTHETIC_NUMBER) {
+    if (Fodselsnummer.isSynthetic(fodselsnummer) && !ALLOW_SYNTHETIC_NUMBERS) {
       throw new IllegalArgumentException("Syntetic fødselsnummer is not allowd" + fodselsnummer);
     }
   }

--- a/src/test/java/no/bekk/bekkopen/person/FodselsnummerCalculatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/FodselsnummerCalculatorTest.java
@@ -3,15 +3,15 @@ package no.bekk.bekkopen.person;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class FodselsnummerCalculatorTest {
 
@@ -22,12 +22,6 @@ public class FodselsnummerCalculatorTest {
 	public void setUpDate() throws Exception {
 		df = new SimpleDateFormat("ddMMyyyy");
 		date = df.parse("09062006");
-	}
-
-	@Test
-	public void testGetFodselsnummerForDateAndGender() throws ParseException {
-		List<Fodselsnummer> options = FodselsnummerCalculator.getFodselsnummerForDateAndGender(date, KJONN.KVINNE);
-		assertTrue("Forventet minst 10 fødselsnumre, men fikk " + options.size(), options.size() > 10);
 	}
 
 	@Test
@@ -52,7 +46,7 @@ public class FodselsnummerCalculatorTest {
 	@Test
 	public void testThatAllGeneratedNumbersAreNotDNumbers() {
 		for(Fodselsnummer fnr : FodselsnummerCalculator.getManyFodselsnummerForDate(date)) {
-			assertTrue("Ugyldig fødselsnummer: " + fnr, Fodselsnummer.isDNumber(fnr.toString()) != true);
+      assertFalse("Ugyldig fødselsnummer: " + fnr, Fodselsnummer.isDNumber(fnr.toString()));
 		}
 	}
 
@@ -76,7 +70,7 @@ public class FodselsnummerCalculatorTest {
 	@Test
 	public void testThatAllGeneratedDNumbersAreDNumbers() {
 		for(Fodselsnummer dnr : FodselsnummerCalculator.getManyDNumberFodselsnummerForDate(date)) {
-			assertTrue("Ugyldig D-nummer: " + dnr, Fodselsnummer.isDNumber(dnr.toString()) == true);
+      assertTrue("Ugyldig D-nummer: " + dnr, Fodselsnummer.isDNumber(dnr.toString()));
 		}
 	}
 

--- a/src/test/java/no/bekk/bekkopen/person/FodselsnummerTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/FodselsnummerTest.java
@@ -1,11 +1,11 @@
 package no.bekk.bekkopen.person;
 
+import org.junit.Before;
+import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-
-import org.junit.Before;
-import org.junit.Test;
 
 public class FodselsnummerTest {
 
@@ -16,7 +16,7 @@ public class FodselsnummerTest {
     private Fodselsnummer sut = null;
 
     @Before
-    public void setUpValidFodselsnummer() throws Exception {
+    public void setUpValidFodselsnummer() {
         sut = new Fodselsnummer(VALID_FODSELSNUMMER);
     }
 
@@ -119,28 +119,6 @@ public class FodselsnummerTest {
     }
 
     @Test
-    public void testIsMale() {
-        assertEquals(false, sut.isMale());
-    }
-
-    @Test
-    public void testIsMaleDNumber() {
-        sut = new Fodselsnummer(D_FODSELSNUMMER);
-        assertEquals(false, sut.isMale());
-    }
-
-    @Test
-    public void testIsFemale() {
-        assertEquals(true, sut.isFemale());
-    }
-
-    @Test
-    public void testIsFemaleDNumber() {
-        sut = new Fodselsnummer(D_FODSELSNUMMER);
-        assertEquals(true, sut.isFemale());
-    }
-
-    @Test
     public void testIsDNumber() {
         assertFalse(Fodselsnummer.isDNumber("01010101006"));
         assertFalse(Fodselsnummer.isDNumber("80000000000"));
@@ -150,5 +128,17 @@ public class FodselsnummerTest {
     @Test
     public void testParseDNumber() {
         assertEquals("07086303651", Fodselsnummer.parseDNumber("47086303651"));
+    }
+
+    @Test
+    public void testParseSynteticNumber() {
+        assertEquals("07086303651", Fodselsnummer.parseSynthenticNumber("07886303651"));
+    }
+
+    @Test
+    public void testIsSynteticNumber() {
+        assertFalse(Fodselsnummer.isSynthetic("01010101006"));
+        assertFalse(Fodselsnummer.isSynthetic("80000000000"));
+        assertTrue(Fodselsnummer.isSynthetic("07886303651"));
     }
 }

--- a/src/test/java/no/bekk/bekkopen/person/FodselsnummerValidatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/FodselsnummerValidatorTest.java
@@ -1,12 +1,12 @@
 package no.bekk.bekkopen.person;
 
+import no.bekk.bekkopen.NoCommonsTestCase;
+import org.junit.Test;
+
 import static no.bekk.bekkopen.common.Checksums.ERROR_INVALID_CHECKSUM;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import no.bekk.bekkopen.NoCommonsTestCase;
-
-import org.junit.Test;
 
 public class FodselsnummerValidatorTest extends NoCommonsTestCase {
 

--- a/src/test/java/no/bekk/bekkopen/person/SyntheticFodselsnummerCalculatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/SyntheticFodselsnummerCalculatorTest.java
@@ -17,12 +17,12 @@ public class SyntheticFodselsnummerCalculatorTest {
 
   @BeforeClass
   public static void setup() {
-    FodselsnummerValidator.FAIL_ON_SYNTHETIC_NUMBER = false;
+    FodselsnummerValidator.ALLOW_SYNTHETIC_NUMBERS = true;
   }
 
   @AfterClass
   public static void taredown() {
-    FodselsnummerValidator.FAIL_ON_SYNTHETIC_NUMBER = true;
+    FodselsnummerValidator.ALLOW_SYNTHETIC_NUMBERS = false;
   }
 
   @Before

--- a/src/test/java/no/bekk/bekkopen/person/SyntheticFodselsnummerCalculatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/SyntheticFodselsnummerCalculatorTest.java
@@ -1,0 +1,50 @@
+package no.bekk.bekkopen.person;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.Assert.assertTrue;
+
+public class SyntheticFodselsnummerCalculatorTest {
+
+  private Date date = null;
+
+  @BeforeClass
+  public static void setup() {
+    FodselsnummerValidator.FAIL_ON_SYNTHETIC_NUMBER = false;
+  }
+
+  @AfterClass
+  public static void taredown() {
+    FodselsnummerValidator.FAIL_ON_SYNTHETIC_NUMBER = true;
+  }
+
+  @Before
+  public void setUpDate() throws Exception {
+    DateFormat df = new SimpleDateFormat("ddMMyyyy");
+    date = df.parse("09062006");
+  }
+
+  @Test
+  public void testThatAllGeneratedSyntheticDNumbersAreValid() {
+    for (Fodselsnummer fnr : FodselsnummerCalculator.getManySynteticDNumberFodselsnummerForDate(date)) {
+      assertTrue("Ugyldig fødselsnummer: " + fnr, FodselsnummerValidator.isValid(fnr.toString()));
+    }
+  }
+
+  @Test
+  public void testThatAtLeastOneSynteticNumberIsGenerated() {
+    assertTrue(FodselsnummerCalculator.getManySynteticFodselsnummerForDate(date).size() >= 1);
+  }
+
+  @Test
+  public void testThatAtLeastOneSynteticDNumberIsGenerated() {
+    assertTrue(FodselsnummerCalculator.getManySynteticDNumberFodselsnummerForDate(date).size() >= 1);
+  }
+}

--- a/src/test/java/no/bekk/bekkopen/person/SyntheticFodselsnummerValidatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/SyntheticFodselsnummerValidatorTest.java
@@ -1,0 +1,27 @@
+package no.bekk.bekkopen.person;
+
+import no.bekk.bekkopen.NoCommonsTestCase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class SyntheticFodselsnummerValidatorTest extends NoCommonsTestCase {
+
+  @BeforeClass
+  public static void setup() {
+    FodselsnummerValidator.FAIL_ON_SYNTHETIC_NUMBER = false;
+  }
+
+  @AfterClass
+  public static void taredown() {
+    FodselsnummerValidator.FAIL_ON_SYNTHETIC_NUMBER = true;
+  }
+
+  @Test
+  public void testSynteticDNumberIsValid() {
+    assertTrue(FodselsnummerValidator.isValid("49860699787"));
+  }
+
+}

--- a/src/test/java/no/bekk/bekkopen/person/SyntheticFodselsnummerValidatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/SyntheticFodselsnummerValidatorTest.java
@@ -11,12 +11,12 @@ public class SyntheticFodselsnummerValidatorTest extends NoCommonsTestCase {
 
   @BeforeClass
   public static void setup() {
-    FodselsnummerValidator.FAIL_ON_SYNTHETIC_NUMBER = false;
+    FodselsnummerValidator.ALLOW_SYNTHETIC_NUMBERS = true;
   }
 
   @AfterClass
   public static void taredown() {
-    FodselsnummerValidator.FAIL_ON_SYNTHETIC_NUMBER = true;
+    FodselsnummerValidator.ALLOW_SYNTHETIC_NUMBERS = false;
   }
 
   @Test


### PR DESCRIPTION
Folkeregisteret vil innføre syntetiske fnr og dnr fra nov 2020. Dette
gjør de for å ikke ha mulighet for å ha skikkelige fnr og dnr i testmiljøene.

Skatteetaten foreslår at man gir en mulighet til å slå av og på
om en skal validere truthy eller falsy på syntetiske fnr/dnr (test/prod).

Jeg har lagt inn en enkelt statisk flagg for å styre dette.
public static boolean FAIL_ON_SYNTHETIC_NUMBER = true;