### PR TITLE
Fjerner tekst om Maven Site

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ APIet er kjapt, standalone, offline og uten masse dependencies.
 
 > **Summary in english**: The NoCommons library is a collection of helper classes for validation, generation and manipulation of domains specific to Norway and Norwegian citizens.
 
-Maven Site: [http://bekkopen.github.com/NoCommons/](http://bekkopen.github.com/NoCommons/)  
-
 # Features
 * Personnummer
   * validering


### PR DESCRIPTION
Fjerner tekst om Maven Site siden lenken gir 404 og det ikke trengs da koden lever på Github