### PR TITLE
Utvidelse av nummerserie for D-nummer (validering)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 4
+charset = utf-8

--- a/src/main/java/no/bekk/bekkopen/person/Fodselsnummer.java
+++ b/src/main/java/no/bekk/bekkopen/person/Fodselsnummer.java
@@ -57,15 +57,29 @@ public class Fodselsnummer extends StringNumber {
 		String result = null;
 		int individnummerInt = Integer.parseInt(getIndividnummer());
 		int birthYear = Integer.parseInt(get2DigitBirthYear());
-		if (individnummerInt <= 499) {
-			result = "19";
-		} else if (individnummerInt >= 500 && birthYear < 40) {
-			result = "20";
-		} else if (individnummerInt >= 500 && individnummerInt <= 749 && birthYear >= 54) {
-			result = "18";
-		} else if (individnummerInt >= 900 && birthYear > 39) {
-			result = "19";
-		}
+
+		if(isDNumber(this.getValue())){
+		  if(individnummerInt >= 500 && individnummerInt <= 599){
+		    result = "18";
+      } else if (individnummerInt <= 199 && birthYear < 40){
+		    result = "19";
+      } else if ((individnummerInt <= 499 || (individnummerInt >= 600 && individnummerInt <= 999)) && birthYear >= 40){
+		    result = "19";
+      } else if (individnummerInt >= 200 && individnummerInt <= 999 && birthYear < 40) {
+        result = "20";
+      }
+    } else {
+      if (individnummerInt <= 499) {
+        result = "19";
+      } else if (individnummerInt >= 500 && birthYear < 40) {
+        result = "20";
+      } else if (individnummerInt >= 500 && individnummerInt <= 749 && birthYear >= 54) {
+        result = "18";
+      } else if (individnummerInt >= 900 && birthYear > 39) {
+        result = "19";
+      }
+    }
+
 		return result;
 	}
 

--- a/src/main/java/no/bekk/bekkopen/person/Fodselsnummer.java
+++ b/src/main/java/no/bekk/bekkopen/person/Fodselsnummer.java
@@ -58,27 +58,27 @@ public class Fodselsnummer extends StringNumber {
 		int individnummerInt = Integer.parseInt(getIndividnummer());
 		int birthYear = Integer.parseInt(get2DigitBirthYear());
 
-		if(isDNumber(this.getValue())){
-		  if(individnummerInt >= 500 && individnummerInt <= 599){
-		    result = "18";
-      } else if (individnummerInt <= 199 && birthYear < 40){
-		    result = "19";
-      } else if ((individnummerInt <= 499 || (individnummerInt >= 600 && individnummerInt <= 999)) && birthYear >= 40){
-		    result = "19";
-      } else if (individnummerInt >= 200 && individnummerInt <= 999 && birthYear < 40) {
-        result = "20";
-      }
-    } else {
-      if (individnummerInt <= 499) {
-        result = "19";
-      } else if (individnummerInt >= 500 && birthYear < 40) {
-        result = "20";
-      } else if (individnummerInt >= 500 && individnummerInt <= 749 && birthYear >= 54) {
-        result = "18";
-      } else if (individnummerInt >= 900 && birthYear > 39) {
-        result = "19";
-      }
-    }
+		if (isDNumber(this.getValue())) {
+			if (individnummerInt >= 500 && individnummerInt <= 599) {
+				result = "18";
+			} else if (individnummerInt <= 199 && birthYear < 40) {
+				result = "19";
+			} else if ((individnummerInt <= 499 || (individnummerInt >= 600 && individnummerInt <= 999)) && birthYear >= 40) {
+				result = "19";
+			} else if (individnummerInt >= 200 && individnummerInt <= 999 && birthYear < 40) {
+				result = "20";
+			}
+		} else {
+			if (individnummerInt <= 499) {
+				result = "19";
+			} else if (individnummerInt >= 500 && birthYear < 40) {
+				result = "20";
+			} else if (individnummerInt >= 500 && individnummerInt <= 749 && birthYear >= 54) {
+				result = "18";
+			} else if (individnummerInt >= 900 && birthYear > 39) {
+				result = "19";
+			}
+		}
 
 		return result;
 	}
@@ -169,15 +169,15 @@ public class Fodselsnummer extends StringNumber {
 		return !isMale();
 	}
 
-  static String parseSynthenticNumber(String fodselsnummer) {
-    if (!isSynthetic(fodselsnummer)) {
-      return fodselsnummer;
-    } else {
-      return fodselsnummer.substring(0, 2) + (getThirdDigit(fodselsnummer) - 8) + fodselsnummer.substring(3);
-    }
-  }
+	static String parseSynthenticNumber(String fodselsnummer) {
+		if (!isSynthetic(fodselsnummer)) {
+			return fodselsnummer;
+		} else {
+			return fodselsnummer.substring(0, 2) + (getThirdDigit(fodselsnummer) - 8) + fodselsnummer.substring(3);
+		}
+	}
 
-  static boolean isSynthetic(String fodselsnummer) {
+	static boolean isSynthetic(String fodselsnummer) {
 		try {
 			int thirdDigit = getThirdDigit(fodselsnummer);
 			if (thirdDigit == 8 || thirdDigit == 9) {
@@ -189,17 +189,17 @@ public class Fodselsnummer extends StringNumber {
 		return false;
 	}
 
-  static boolean isDNumber(String fodselsnummer) {
-    try {
-      int firstDigit = getFirstDigit(fodselsnummer);
-      if (firstDigit > 3 && firstDigit < 8) {
-        return true;
-      }
-    } catch (IllegalArgumentException e) {
-      // ignore
-    }
-    return false;
-  }
+	static boolean isDNumber(String fodselsnummer) {
+		try {
+			int firstDigit = getFirstDigit(fodselsnummer);
+			if (firstDigit > 3 && firstDigit < 8) {
+				return true;
+			}
+		} catch (IllegalArgumentException e) {
+			// ignore
+		}
+		return false;
+	}
 
 	static String parseDNumber(String fodselsnummer) {
 		if (!isDNumber(fodselsnummer)) {
@@ -226,7 +226,7 @@ public class Fodselsnummer extends StringNumber {
 	}
 
 	@Override
-	public String toString(){
+	public String toString() {
 		return super.getValue();
 	}
 }

--- a/src/test/java/no/bekk/bekkopen/person/FodselsnummerCalculatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/FodselsnummerCalculatorTest.java
@@ -20,7 +20,7 @@ public class FodselsnummerCalculatorTest {
 
 	@BeforeEach
 	public void setUpDate() throws Exception {
-		df = new SimpleDateFormat("ddMMyyyy");
+		df   = new SimpleDateFormat("ddMMyyyy");
 		date = df.parse("09062006");
 	}
 
@@ -38,15 +38,15 @@ public class FodselsnummerCalculatorTest {
 
 	@Test
 	public void testThatAllGeneratedNumbersAreValid() {
-		for(Fodselsnummer fnr : FodselsnummerCalculator.getManyFodselsnummerForDate(date)) {
+		for (Fodselsnummer fnr : FodselsnummerCalculator.getManyFodselsnummerForDate(date)) {
 			assertTrue(FodselsnummerValidator.isValid(fnr.toString()), "Ugyldig fødselsnummer: " + fnr);
 		}
 	}
 
 	@Test
 	public void testThatAllGeneratedNumbersAreNotDNumbers() {
-		for(Fodselsnummer fnr : FodselsnummerCalculator.getManyFodselsnummerForDate(date)) {
-      assertFalse(Fodselsnummer.isDNumber(fnr.toString()), "Ugyldig fødselsnummer: " + fnr);
+		for (Fodselsnummer fnr : FodselsnummerCalculator.getManyFodselsnummerForDate(date)) {
+			assertFalse(Fodselsnummer.isDNumber(fnr.toString()), "Ugyldig fødselsnummer: " + fnr);
 		}
 	}
 
@@ -62,21 +62,21 @@ public class FodselsnummerCalculatorTest {
 
 	@Test
 	public void testThatAtLeastOneDNumberIsGeneratedsas() throws ParseException {
-    assertEquals(82, FodselsnummerCalculator.getManyDNumberFodselsnummerForDate(df.parse("06061878")).size());
-    assertEquals(164, FodselsnummerCalculator.getManyDNumberFodselsnummerForDate(df.parse("12101921")).size());
-  }
+		assertEquals(82, FodselsnummerCalculator.getManyDNumberFodselsnummerForDate(df.parse("06061878")).size());
+		assertEquals(164, FodselsnummerCalculator.getManyDNumberFodselsnummerForDate(df.parse("12101921")).size());
+	}
 
 	@Test
 	public void testThatAllGeneratedDNumbersAreValid() {
-		for(Fodselsnummer dnr : FodselsnummerCalculator.getManyDNumberFodselsnummerForDate(date)) {
+		for (Fodselsnummer dnr : FodselsnummerCalculator.getManyDNumberFodselsnummerForDate(date)) {
 			assertTrue(FodselsnummerValidator.isValid(dnr.toString()), "Ugyldig D-nummer: " + dnr);
 		}
 	}
 
 	@Test
 	public void testThatAllGeneratedDNumbersAreDNumbers() {
-		for(Fodselsnummer dnr : FodselsnummerCalculator.getManyDNumberFodselsnummerForDate(date)) {
-      assertTrue(Fodselsnummer.isDNumber(dnr.toString()), "Ugyldig D-nummer: " + dnr);
+		for (Fodselsnummer dnr : FodselsnummerCalculator.getManyDNumberFodselsnummerForDate(date)) {
+			assertTrue(Fodselsnummer.isDNumber(dnr.toString()), "Ugyldig D-nummer: " + dnr);
 		}
 	}
 
@@ -95,7 +95,7 @@ public class FodselsnummerCalculatorTest {
 	}
 
 	@Test
-	public void testOneFodselsnummer() throws ParseException{
+	public void testOneFodselsnummer() throws ParseException {
 		date = df.parse("01121980");
 		Fodselsnummer fodselsnummer = FodselsnummerCalculator.getFodselsnummerForDate(date);
 		assertTrue(FodselsnummerValidator.isValid(fodselsnummer.toString()));

--- a/src/test/java/no/bekk/bekkopen/person/FodselsnummerCalculatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/FodselsnummerCalculatorTest.java
@@ -61,6 +61,12 @@ public class FodselsnummerCalculatorTest {
 	}
 
 	@Test
+	public void testThatAtLeastOneDNumberIsGeneratedsas() throws ParseException {
+    assertEquals(82, FodselsnummerCalculator.getManyDNumberFodselsnummerForDate(df.parse("06061878")).size());
+    assertEquals(164, FodselsnummerCalculator.getManyDNumberFodselsnummerForDate(df.parse("12101921")).size());
+  }
+
+	@Test
 	public void testThatAllGeneratedDNumbersAreValid() {
 		for(Fodselsnummer dnr : FodselsnummerCalculator.getManyDNumberFodselsnummerForDate(date)) {
 			assertTrue(FodselsnummerValidator.isValid(dnr.toString()), "Ugyldig D-nummer: " + dnr);

--- a/src/test/java/no/bekk/bekkopen/person/FodselsnummerTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/FodselsnummerTest.java
@@ -9,142 +9,142 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FodselsnummerTest {
 
-    private static final String VALID_FODSELSNUMMER = "01010123476";
+	private static final String VALID_FODSELSNUMMER = "01010123476";
 
-    private static final String D_FODSELSNUMMER = "41010119500";//Invalid but valid is tested in FodselsnummerValidatorTest
+	private static final String D_FODSELSNUMMER = "41010119500";//Invalid but valid is tested in FodselsnummerValidatorTest
 
-    private Fodselsnummer sut = null;
+	private Fodselsnummer sut = null;
 
-    @BeforeEach
-    public void setUpValidFodselsnummer() {
-        sut = new Fodselsnummer(VALID_FODSELSNUMMER);
-    }
+	@BeforeEach
+	public void setUpValidFodselsnummer() {
+		sut = new Fodselsnummer(VALID_FODSELSNUMMER);
+	}
 
-    @Test
-    public void testGetDateAndMonth() {
-        assertEquals("0101", sut.getDateAndMonth());
-    }
+	@Test
+	public void testGetDateAndMonth() {
+		assertEquals("0101", sut.getDateAndMonth());
+	}
 
-    @Test
-    public void testGetDayInMonth() {
-        assertEquals("01", sut.getDayInMonth());
-        sut = new Fodselsnummer(D_FODSELSNUMMER);
-        assertEquals("01", sut.getDayInMonth());
-    }
+	@Test
+	public void testGetDayInMonth() {
+		assertEquals("01", sut.getDayInMonth());
+		sut = new Fodselsnummer(D_FODSELSNUMMER);
+		assertEquals("01", sut.getDayInMonth());
+	}
 
-    @Test
-    public void testGetMonth() {
-        assertEquals("01", sut.getMonth());
-    }
+	@Test
+	public void testGetMonth() {
+		assertEquals("01", sut.getMonth());
+	}
 
-    @Test
-    public void testGetDateAndMonthDNumber() {
-        sut = new Fodselsnummer(D_FODSELSNUMMER);
-        assertEquals("0101", sut.getDateAndMonth());
-    }
+	@Test
+	public void testGetDateAndMonthDNumber() {
+		sut = new Fodselsnummer(D_FODSELSNUMMER);
+		assertEquals("0101", sut.getDateAndMonth());
+	}
 
-    @Test
-    public void testGetCentury() {
-        sut = new Fodselsnummer("01016666609");
-        assertEquals("18", sut.getCentury());
+	@Test
+	public void testGetCentury() {
+		sut = new Fodselsnummer("01016666609");
+		assertEquals("18", sut.getCentury());
 
-        sut = new Fodselsnummer("01015466609");
-        assertEquals("18", sut.getCentury());
+		sut = new Fodselsnummer("01015466609");
+		assertEquals("18", sut.getCentury());
 
-        sut = new Fodselsnummer("01016633301");
-        assertEquals("19", sut.getCentury());
+		sut = new Fodselsnummer("01016633301");
+		assertEquals("19", sut.getCentury());
 
-        sut = new Fodselsnummer("01019196697");
-        assertEquals("19", sut.getCentury());
+		sut = new Fodselsnummer("01019196697");
+		assertEquals("19", sut.getCentury());
 
-        sut = new Fodselsnummer("01013366671");
-        assertEquals("20", sut.getCentury());
+		sut = new Fodselsnummer("01013366671");
+		assertEquals("20", sut.getCentury());
 
-        // DNumber...
-        sut = new Fodselsnummer("41016656638");
-        assertEquals("18", sut.getCentury());
+		// DNumber...
+		sut = new Fodselsnummer("41016656638");
+		assertEquals("18", sut.getCentury());
 
-        sut = new Fodselsnummer("41016633301");
-        assertEquals("19", sut.getCentury());
+		sut = new Fodselsnummer("41016633301");
+		assertEquals("19", sut.getCentury());
 
-        sut = new Fodselsnummer("41019196697");
-        assertEquals("19", sut.getCentury());
+		sut = new Fodselsnummer("41019196697");
+		assertEquals("19", sut.getCentury());
 
-        sut = new Fodselsnummer("41013366671");
-        assertEquals("20", sut.getCentury());
+		sut = new Fodselsnummer("41013366671");
+		assertEquals("20", sut.getCentury());
 
-        sut = new Fodselsnummer("41014061078");
-        assertEquals("19", sut.getCentury());
+		sut = new Fodselsnummer("41014061078");
+		assertEquals("19", sut.getCentury());
 
-        sut = new Fodselsnummer("41010021861");
-        assertEquals("20", sut.getCentury());
-    }
+		sut = new Fodselsnummer("41010021861");
+		assertEquals("20", sut.getCentury());
+	}
 
-    @Test
-    public void testGet2DigitBirthYear() {
-        assertEquals("01", sut.get2DigitBirthYear());
-    }
+	@Test
+	public void testGet2DigitBirthYear() {
+		assertEquals("01", sut.get2DigitBirthYear());
+	}
 
-    @Test
-    public void testGetBirthYear() {
-        assertEquals("1901", sut.getBirthYear());
-        sut = new Fodselsnummer(D_FODSELSNUMMER);
-        assertEquals("1901", sut.getBirthYear());
-    }
+	@Test
+	public void testGetBirthYear() {
+		assertEquals("1901", sut.getBirthYear());
+		sut = new Fodselsnummer(D_FODSELSNUMMER);
+		assertEquals("1901", sut.getBirthYear());
+	}
 
-    @Test
-    public void testGetDateOfBirth() {
-        assertEquals("010101", sut.getDateOfBirth());
-    }
+	@Test
+	public void testGetDateOfBirth() {
+		assertEquals("010101", sut.getDateOfBirth());
+	}
 
-    @Test
-    public void testGetDateOfBirthDNumber() {
-        sut = new Fodselsnummer(D_FODSELSNUMMER);
-        assertEquals("010101", sut.getDateOfBirth());
-    }
+	@Test
+	public void testGetDateOfBirthDNumber() {
+		sut = new Fodselsnummer(D_FODSELSNUMMER);
+		assertEquals("010101", sut.getDateOfBirth());
+	}
 
-    @Test
-    public void testGetPersonnummer() {
-        assertEquals("23476", sut.getPersonnummer());
-    }
+	@Test
+	public void testGetPersonnummer() {
+		assertEquals("23476", sut.getPersonnummer());
+	}
 
-    @Test
-    public void testGetIndividnummer() {
-        assertEquals("234", sut.getIndividnummer());
-    }
+	@Test
+	public void testGetIndividnummer() {
+		assertEquals("234", sut.getIndividnummer());
+	}
 
-    @Test
-    public void testGetGenderDigit() {
-        assertEquals(4, sut.getGenderDigit());
-    }
+	@Test
+	public void testGetGenderDigit() {
+		assertEquals(4, sut.getGenderDigit());
+	}
 
-    @Test
-    public void testGetChecksumDigits() {
-        assertEquals(7, sut.getChecksumDigit1());
-        assertEquals(6, sut.getChecksumDigit2());
-    }
+	@Test
+	public void testGetChecksumDigits() {
+		assertEquals(7, sut.getChecksumDigit1());
+		assertEquals(6, sut.getChecksumDigit2());
+	}
 
-    @Test
-    public void testIsDNumber() {
-        assertFalse(Fodselsnummer.isDNumber("01010101006"));
-        assertFalse(Fodselsnummer.isDNumber("80000000000"));
-        assertTrue(Fodselsnummer.isDNumber("47086303651"));
-    }
+	@Test
+	public void testIsDNumber() {
+		assertFalse(Fodselsnummer.isDNumber("01010101006"));
+		assertFalse(Fodselsnummer.isDNumber("80000000000"));
+		assertTrue(Fodselsnummer.isDNumber("47086303651"));
+	}
 
-    @Test
-    public void testParseDNumber() {
-        assertEquals("07086303651", Fodselsnummer.parseDNumber("47086303651"));
-    }
+	@Test
+	public void testParseDNumber() {
+		assertEquals("07086303651", Fodselsnummer.parseDNumber("47086303651"));
+	}
 
-    @Test
-    public void testParseSynteticNumber() {
-        assertEquals("07086303651", Fodselsnummer.parseSynthenticNumber("07886303651"));
-    }
+	@Test
+	public void testParseSynteticNumber() {
+		assertEquals("07086303651", Fodselsnummer.parseSynthenticNumber("07886303651"));
+	}
 
-    @Test
-    public void testIsSynteticNumber() {
-        assertFalse(Fodselsnummer.isSynthetic("01010101006"));
-        assertFalse(Fodselsnummer.isSynthetic("80000000000"));
-        assertTrue(Fodselsnummer.isSynthetic("07886303651"));
-    }
+	@Test
+	public void testIsSynteticNumber() {
+		assertFalse(Fodselsnummer.isSynthetic("01010101006"));
+		assertFalse(Fodselsnummer.isSynthetic("80000000000"));
+		assertTrue(Fodselsnummer.isSynthetic("07886303651"));
+	}
 }

--- a/src/test/java/no/bekk/bekkopen/person/FodselsnummerTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/FodselsnummerTest.java
@@ -61,7 +61,7 @@ public class FodselsnummerTest {
 		assertEquals("20", sut.getCentury());
 
 		// DNumber...
-		sut = new Fodselsnummer("41016656638");
+		sut = new Fodselsnummer("46067853407");
 		assertEquals("18", sut.getCentury());
 
 		sut = new Fodselsnummer("41016633301");

--- a/src/test/java/no/bekk/bekkopen/person/FodselsnummerTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/FodselsnummerTest.java
@@ -11,7 +11,7 @@ public class FodselsnummerTest {
 
     private static final String VALID_FODSELSNUMMER = "01010123476";
 
-    private static final String D_FODSELSNUMMER = "41010123476";//Invalid but valid is tested in FodselsnummerValidatorTest
+    private static final String D_FODSELSNUMMER = "41010119500";//Invalid but valid is tested in FodselsnummerValidatorTest
 
     private Fodselsnummer sut = null;
 
@@ -61,7 +61,7 @@ public class FodselsnummerTest {
         assertEquals("20", sut.getCentury());
 
         // DNumber...
-        sut = new Fodselsnummer("41016666609");
+        sut = new Fodselsnummer("41016656638");
         assertEquals("18", sut.getCentury());
 
         sut = new Fodselsnummer("41016633301");
@@ -71,6 +71,12 @@ public class FodselsnummerTest {
         assertEquals("19", sut.getCentury());
 
         sut = new Fodselsnummer("41013366671");
+        assertEquals("20", sut.getCentury());
+
+        sut = new Fodselsnummer("41014061078");
+        assertEquals("19", sut.getCentury());
+
+        sut = new Fodselsnummer("41010021861");
         assertEquals("20", sut.getCentury());
     }
 

--- a/src/test/java/no/bekk/bekkopen/person/FodselsnummerValidatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/FodselsnummerValidatorTest.java
@@ -13,65 +13,65 @@ public class FodselsnummerValidatorTest {
 
 	@Test
 	public void testInvalidFodselsnummerWrongLength() {
-	    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
-	            () -> FodselsnummerValidator.validateSyntax("0123456789"));
-	    assertThat(thrown.getMessage(), containsString(FodselsnummerValidator.ERROR_SYNTAX));
+		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+			() -> FodselsnummerValidator.validateSyntax("0123456789"));
+		assertThat(thrown.getMessage(), containsString(FodselsnummerValidator.ERROR_SYNTAX));
 	}
 
 	@Test
 	public void testInvalidFodselsnummerNotDigits() {
-	    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
-                () -> FodselsnummerValidator.validateSyntax("abcdefghijk"));
-        assertThat(thrown.getMessage(), containsString(FodselsnummerValidator.ERROR_SYNTAX));
+		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+			() -> FodselsnummerValidator.validateSyntax("abcdefghijk"));
+		assertThat(thrown.getMessage(), containsString(FodselsnummerValidator.ERROR_SYNTAX));
 	}
 
 	@Test
 	public void testInvalidIndividnummer() {
-	    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
-                () -> FodselsnummerValidator.validateIndividnummer("01015780000"));
-        assertThat(thrown.getMessage(), containsString(FodselsnummerValidator.ERROR_INVALID_INDIVIDNUMMER));
+		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+			() -> FodselsnummerValidator.validateIndividnummer("01015780000"));
+		assertThat(thrown.getMessage(), containsString(FodselsnummerValidator.ERROR_INVALID_INDIVIDNUMMER));
 	}
 
 	@Test
 	public void testInvalidDateMonthMax() {
-	    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
-	            () -> FodselsnummerValidator.validateDate("01130400000"));
-	    assertThat(thrown.getMessage(), containsString(FodselsnummerValidator.ERROR_INVALID_DATE));
+		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+			() -> FodselsnummerValidator.validateDate("01130400000"));
+		assertThat(thrown.getMessage(), containsString(FodselsnummerValidator.ERROR_INVALID_DATE));
 	}
 
 	@Test
 	public void testInvalidDateMonthMin() {
-	    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
-	            () -> FodselsnummerValidator.validateDate("01000400000"));
-	    assertThat(thrown.getMessage(), containsString(FodselsnummerValidator.ERROR_INVALID_DATE));
+		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+			() -> FodselsnummerValidator.validateDate("01000400000"));
+		assertThat(thrown.getMessage(), containsString(FodselsnummerValidator.ERROR_INVALID_DATE));
 	}
 
 	@Test
 	public void testInvalidDateDayMin() {
-	    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
-	            () -> FodselsnummerValidator.validateDate("00120467800"));
-	    assertThat(thrown.getMessage(), containsString(FodselsnummerValidator.ERROR_INVALID_DATE));
+		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+			() -> FodselsnummerValidator.validateDate("00120467800"));
+		assertThat(thrown.getMessage(), containsString(FodselsnummerValidator.ERROR_INVALID_DATE));
 	}
 
 	@Test
 	public void testInvalidDateDayMax() {
-	    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
-	            () -> FodselsnummerValidator.validateDate("32120400000"));
-	    assertThat(thrown.getMessage(), containsString(FodselsnummerValidator.ERROR_INVALID_DATE));
+		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+			() -> FodselsnummerValidator.validateDate("32120400000"));
+		assertThat(thrown.getMessage(), containsString(FodselsnummerValidator.ERROR_INVALID_DATE));
 	}
 
 	@Test
 	public void testInvalidDateLeapDay() {
-	    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
-                () -> FodselsnummerValidator.validateDate("29020700000"));
-        assertThat(thrown.getMessage(), containsString(FodselsnummerValidator.ERROR_INVALID_DATE));
+		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+			() -> FodselsnummerValidator.validateDate("29020700000"));
+		assertThat(thrown.getMessage(), containsString(FodselsnummerValidator.ERROR_INVALID_DATE));
 	}
 
 	@Test
 	public void testInvalidFodselsnummerChecksum() {
-	    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
-	            () -> FodselsnummerValidator.validateChecksums("01010101010"));
-	    assertThat(thrown.getMessage(), containsString(ERROR_INVALID_CHECKSUM));
+		IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+			() -> FodselsnummerValidator.validateChecksums("01010101010"));
+		assertThat(thrown.getMessage(), containsString(ERROR_INVALID_CHECKSUM));
 	}
 
 	@Test
@@ -89,13 +89,13 @@ public class FodselsnummerValidatorTest {
 		assertTrue(FodselsnummerValidator.isValid("47086303651"));
 	}
 
-  @Test
-  void testDNumberIsValidUtvidelse2021() {
+	@Test
+	void testDNumberIsValidUtvidelse2021() {
 		assertTrue(FodselsnummerValidator.isValid("41014061078"));
 		assertTrue(FodselsnummerValidator.isValid("41010021861"));
-  }
+	}
 
-  @Test
+	@Test
 	public void testGetDNumber() {
 		FodselsnummerValidator.getFodselsnummer("47086303651");
 	}

--- a/src/test/java/no/bekk/bekkopen/person/FodselsnummerValidatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/FodselsnummerValidatorTest.java
@@ -89,7 +89,13 @@ public class FodselsnummerValidatorTest {
 		assertTrue(FodselsnummerValidator.isValid("47086303651"));
 	}
 
-	@Test
+  @Test
+  void testDNumberIsValidUtvidelse2021() {
+		assertTrue(FodselsnummerValidator.isValid("41014061078"));
+		assertTrue(FodselsnummerValidator.isValid("41010021861"));
+  }
+
+  @Test
 	public void testGetDNumber() {
 		FodselsnummerValidator.getFodselsnummer("47086303651");
 	}

--- a/src/test/java/no/bekk/bekkopen/person/SyntheticFodselsnummerCalculatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/SyntheticFodselsnummerCalculatorTest.java
@@ -13,38 +13,38 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SyntheticFodselsnummerCalculatorTest {
 
-  private Date date = null;
+	private Date date = null;
 
-  @BeforeAll
-  public static void setup() {
-    FodselsnummerValidator.ALLOW_SYNTHETIC_NUMBERS = true;
-  }
+	@BeforeAll
+	public static void setup() {
+		FodselsnummerValidator.ALLOW_SYNTHETIC_NUMBERS = true;
+	}
 
-  @AfterAll
-  public static void taredown() {
-    FodselsnummerValidator.ALLOW_SYNTHETIC_NUMBERS = false;
-  }
+	@AfterAll
+	public static void taredown() {
+		FodselsnummerValidator.ALLOW_SYNTHETIC_NUMBERS = false;
+	}
 
-  @BeforeEach
-  public void setUpDate() throws Exception {
-    DateFormat df = new SimpleDateFormat("ddMMyyyy");
-    date = df.parse("09062006");
-  }
+	@BeforeEach
+	public void setUpDate() throws Exception {
+		DateFormat df = new SimpleDateFormat("ddMMyyyy");
+		date = df.parse("09062006");
+	}
 
-  @Test
-  public void testThatAllGeneratedSyntheticDNumbersAreValid() {
-    for (Fodselsnummer fnr : FodselsnummerCalculator.getManySynteticDNumberFodselsnummerForDate(date)) {
-      assertTrue(FodselsnummerValidator.isValid(fnr.toString()), "Ugyldig fødselsnummer: " + fnr);
-    }
-  }
+	@Test
+	public void testThatAllGeneratedSyntheticDNumbersAreValid() {
+		for (Fodselsnummer fnr : FodselsnummerCalculator.getManySynteticDNumberFodselsnummerForDate(date)) {
+			assertTrue(FodselsnummerValidator.isValid(fnr.toString()), "Ugyldig fødselsnummer: " + fnr);
+		}
+	}
 
-  @Test
-  public void testThatAtLeastOneSynteticNumberIsGenerated() {
-    assertTrue(FodselsnummerCalculator.getManySynteticFodselsnummerForDate(date).size() >= 1);
-  }
+	@Test
+	public void testThatAtLeastOneSynteticNumberIsGenerated() {
+		assertTrue(FodselsnummerCalculator.getManySynteticFodselsnummerForDate(date).size() >= 1);
+	}
 
-  @Test
-  public void testThatAtLeastOneSynteticDNumberIsGenerated() {
-    assertTrue(FodselsnummerCalculator.getManySynteticDNumberFodselsnummerForDate(date).size() >= 1);
-  }
+	@Test
+	public void testThatAtLeastOneSynteticDNumberIsGenerated() {
+		assertTrue(FodselsnummerCalculator.getManySynteticDNumberFodselsnummerForDate(date).size() >= 1);
+	}
 }

--- a/src/test/java/no/bekk/bekkopen/person/SyntheticFodselsnummerValidatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/SyntheticFodselsnummerValidatorTest.java
@@ -23,4 +23,14 @@ public class SyntheticFodselsnummerValidatorTest {
     assertTrue(FodselsnummerValidator.isValid("49860699787"));
   }
 
+  @Test
+  void testSynteticDNumberIsValidUtvidelse2021() {
+		assertTrue(FodselsnummerValidator.isValid("41814061033"));
+		assertTrue(FodselsnummerValidator.isValid("41814065640"));
+		assertTrue(FodselsnummerValidator.isValid("41814075603"));
+
+		assertTrue(FodselsnummerValidator.isValid("41810021827"));
+		assertTrue(FodselsnummerValidator.isValid("41810025091"));
+		assertTrue(FodselsnummerValidator.isValid("41810034422"));
+  }
 }


### PR DESCRIPTION
ref.:
https://skatteetaten.github.io/folkeregisteret-api-dokumentasjon/sporsmal-og-svar/

Jeg leser det slik at det er kun D-nummer (ref. sitat i under) som skal
påvirkes av det nye regimet. Det er ny type logikk, og vi må derfor ha
forskjellige nummerserier i individnummer om det er D-nummer eller vanlig
tildelt nummer.

Jeg har lagt inn eksempler på syntetiske nummere samt "ekte" D-nummer.

ref.:https://skatteetaten.github.io/folkeregisteret-api-dokumentasjon/nyheter/
under "2021-06-24 - Utvidelse av D-nummerserien"
Sitat:
> Konsumenter som benytter individnummeret til å utlede korrekt fødselsår
for D-nummerpersoner må endre sine systemløsninger. Endringen vil
produksjonssettes medio august 2021 og det vil kunne tildeles
D-numre med nye nummerserier umiddelbart.