### PR TITLE
Some dependency updates in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<packaging>jar</packaging>
 	<version>0-SNAPSHOT</version>
 	<name>NoCommons</name>
-	<url>http://bekkopen.github.com/NoCommons/</url>
+	<url>https://bekkopen.github.com/NoCommons/</url>
 	<description>
 		The NoCommons library is a collection of helper classes for manipulation and validation of data specific to
 		Norway and Norwegian citizens.
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.8.2</version>
+      <version>5.9.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -127,7 +127,7 @@
     <dependency>
       <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
-      <version>6.2.2.Final</version>
+      <version>6.2.5.Final</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -149,12 +149,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M5</version>
+        <version>3.0.0-M7</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
         <configuration>
           <archive>
             <manifestEntries>
@@ -187,7 +187,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>2.4</version>
+            <version>3.2.1</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -202,7 +202,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.10.4</version>
+            <version>3.4.1</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>


### PR DESCRIPTION
There are other dependencies that are far behind or have changed to a different namespace, but require code changes to upgrade. That can be tackled later.