### PR TITLE
Move away from EOL Java8, to Java 11

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [ '1.8', '11', '17' ]
+        java: [ '11', '17' ]
 
     name: Java ${{ matrix.java }} NoCommons
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -242,8 +242,8 @@
 
   <properties>
     <!-- Dependency version -->
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/src/test/java/no/bekk/bekkopen/mail/MailValidatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/mail/MailValidatorTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -22,7 +21,7 @@ import no.bekk.bekkopen.mail.model.Poststed;
 public class MailValidatorTest {
     private static final Poststed HAMAR = new Poststed("Hamar");
 
-    private static final List<PostInfo> postInfo = Arrays.asList(
+    private static final List<PostInfo> postInfo = List.of(
         new PostInfo(
             new Postnummer("4633"),
             new Poststed("KRISTIANSAND S"),


### PR DESCRIPTION
Could use Java 17 but for best compatibility, safer to use 11 until it is EOL.

There's probably much more code that could be simplified, but that can come later.