### PR TITLE
Legger til mulighet for å bruke testidenter fra norsk helsenett (+65)

### DIFF
--- a/src/main/java/no/bekk/bekkopen/person/Fodselsnummer.java
+++ b/src/main/java/no/bekk/bekkopen/person/Fodselsnummer.java
@@ -47,7 +47,7 @@ public class Fodselsnummer extends StringNumber {
 	 * @return A String containing the date and month of birth.
 	 */
 	public String getDateAndMonth() {
-		return parseSynthenticNumber(parseDNumber(getValue())).substring(0, 4);
+		return parseSyntheticNumber(parseDNumber(getValue())).substring(0, 4);
 	}
 
 	/**
@@ -57,7 +57,7 @@ public class Fodselsnummer extends StringNumber {
 	 * @return A String containing the date of birth
 	 */
 	public String getDayInMonth() {
-		return parseSynthenticNumber(parseDNumber(getValue())).substring(0, 2);
+		return parseSyntheticNumber(parseDNumber(getValue())).substring(0, 2);
 	}
 
 	/**
@@ -67,7 +67,7 @@ public class Fodselsnummer extends StringNumber {
 	 * @return A String containing the date of birth
 	 */
 	public String getMonth() {
-		return parseSynthenticNumber(parseDNumber(getValue())).substring(2, 4);
+		return parseSyntheticNumber(parseDNumber(getValue())).substring(2, 4);
 	}
 
 	/**
@@ -126,7 +126,7 @@ public class Fodselsnummer extends StringNumber {
 	 * @return A String containing the date and month of birth.
 	 */
 	public String getDateOfBirth() {
-		return parseSynthenticNumber(parseDNumber(getValue())).substring(0, 6);
+		return parseSyntheticNumber(parseDNumber(getValue())).substring(0, 6);
 	}
 
 	/**
@@ -195,18 +195,36 @@ public class Fodselsnummer extends StringNumber {
 		return !isMale();
 	}
 
-	static String parseSynthenticNumber(String fodselsnummer) {
+	static String parseSyntheticNumber(String fodselsnummer) {
 		if (!isSynthetic(fodselsnummer)) {
 			return fodselsnummer;
 		} else {
-			return fodselsnummer.substring(0, 2) + (getThirdDigit(fodselsnummer) - 8) + fodselsnummer.substring(3);
+
+			int monthNumber = Integer.parseInt(fodselsnummer.substring(2, 4));
+
+			//Skatteetaten - synthetic numbers
+			if (monthNumber >= 81 && monthNumber <= 92){
+
+				return fodselsnummer.substring(0, 2) + (getThirdDigit(fodselsnummer) - 8) + fodselsnummer.substring(3);
+			}
+
+			//Norsk helsenett - synthetic numbers
+			if (monthNumber >= 66 && monthNumber <= 77 ) {
+				String month = Integer.toString(monthNumber - 65);
+				if (month.length() == 1){
+					month = "0" + month;
+				}
+				return fodselsnummer.substring(0, 2) + month + fodselsnummer.substring(4);
+			}
+
+			throw new IllegalArgumentException(fodselsnummer + " is not a valid synthethic number");
 		}
 	}
 
 	static boolean isSynthetic(String fodselsnummer) {
 		try {
-			int thirdDigit = getThirdDigit(fodselsnummer);
-			if (thirdDigit == 8 || thirdDigit == 9) {
+			int monthNumber = Integer.parseInt(fodselsnummer.substring(2, 4));
+			if ((monthNumber >= 81 && monthNumber <= 92) || (monthNumber >= 66 && monthNumber <= 77)) {
 				return true;
 			}
 		} catch (IllegalArgumentException e) {

--- a/src/main/java/no/bekk/bekkopen/person/FodselsnummerCalculator.java
+++ b/src/main/java/no/bekk/bekkopen/person/FodselsnummerCalculator.java
@@ -95,7 +95,7 @@ public class FodselsnummerCalculator {
 	 * @return A List with Fodelsnummer instances
 	 */
 
-	public static List<Fodselsnummer> getManySynteticFodselsnummerForDate(Date date) {
+	public static List<Fodselsnummer> getManySyntheticFodselsnummerForDate(Date date) {
 		if (date == null) {
 			throw new IllegalArgumentException();
 		}
@@ -115,7 +115,7 @@ public class FodselsnummerCalculator {
 	 * @return A List with Fodelsnummer instances
 	 */
 
-	public static List<Fodselsnummer> getManySynteticDNumberFodselsnummerForDate(Date date) {
+	public static List<Fodselsnummer> getManySyntheticDNumberFodselsnummerForDate(Date date) {
 		if (date == null) {
 			throw new IllegalArgumentException();
 		}

--- a/src/main/java/no/bekk/bekkopen/person/FodselsnummerValidator.java
+++ b/src/main/java/no/bekk/bekkopen/person/FodselsnummerValidator.java
@@ -46,7 +46,7 @@ import static no.bekk.bekkopen.common.Checksums.calculateMod11CheckSum;
  * Birth date is modified by adding 4 on the first digit
  *
  * The Norwegian registry Det Norske Folkeregister has decided
- * that it will create syntetic ssn for its testpopulation.
+ * that it will create synthetic ssn for its test population.
  * This validator will can now validate true for Fodselsnummer that has month +80
  * for synthetic fnr/dnr
  */
@@ -66,10 +66,9 @@ public class FodselsnummerValidator extends StringNumberValidator implements Con
   /**
    * Truthy validation of synthetic fnr/dnr is true. You are adviced to
    * set til value to true in test environments where you expect
-   * syntetic fnr/dnr to appair.
+   * synthetic fnr/dnr to appear.
    */
 	public static boolean ALLOW_SYNTHETIC_NUMBERS = false;
-
   static {
     final URL flag = FodselsnummerValidator.class.getResource("/no.bekk.bekkopen.person.allow_synthetic_numbers.flag");
     if (flag != null) {
@@ -97,7 +96,7 @@ public class FodselsnummerValidator extends StringNumberValidator implements Con
 
   private static void validateSynthetic(String fodselsnummer) {
     if (Fodselsnummer.isSynthetic(fodselsnummer) && !ALLOW_SYNTHETIC_NUMBERS) {
-      throw new IllegalArgumentException("Syntetic fødselsnummer is not allowd" + fodselsnummer);
+      throw new IllegalArgumentException("Synthetic fødselsnummer is not allowd" + fodselsnummer);
     }
   }
 

--- a/src/test/java/no/bekk/bekkopen/person/FodselsnummerTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/FodselsnummerTest.java
@@ -163,14 +163,28 @@ public class FodselsnummerTest {
 	}
 
 	@Test
-	public void testParseSynteticNumber() {
-		assertEquals("07086303651", Fodselsnummer.parseSynthenticNumber("07886303651"));
+	public void testParseSyntheticNumber() {
+
+		//+80 on birth month 1-12
+		assertEquals("07086303651", Fodselsnummer.parseSyntheticNumber("07886303651"));
+
+		//+65 on birth month 1-4
+		assertEquals("07026303651", Fodselsnummer.parseSyntheticNumber("07676303651"));
+
+		//+65 on birth month 5-9
+		assertEquals("07056303651", Fodselsnummer.parseSyntheticNumber("07706303651"));
+
+		//+65 on birth month 10-12
+		assertEquals("07116303651", Fodselsnummer.parseSyntheticNumber("07766303651"));
 	}
 
 	@Test
-	public void testIsSynteticNumber() {
+	public void testIsSyntheticNumber() {
 		assertFalse(Fodselsnummer.isSynthetic("01010101006"));
 		assertFalse(Fodselsnummer.isSynthetic("80000000000"));
 		assertTrue(Fodselsnummer.isSynthetic("07886303651"));
+		assertTrue(Fodselsnummer.isSynthetic("07916303651"));
+		assertTrue(Fodselsnummer.isSynthetic("07666303651"));
+		assertTrue(Fodselsnummer.isSynthetic("07766303651"));
 	}
 }

--- a/src/test/java/no/bekk/bekkopen/person/SyntheticFodselsnummerCalculatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/SyntheticFodselsnummerCalculatorTest.java
@@ -47,7 +47,7 @@ public class SyntheticFodselsnummerCalculatorTest {
 	}
 
 	@AfterAll
-	public static void taredown() {
+	public static void teardown() {
 		FodselsnummerValidator.ALLOW_SYNTHETIC_NUMBERS = false;
 	}
 
@@ -59,18 +59,18 @@ public class SyntheticFodselsnummerCalculatorTest {
 
 	@Test
 	public void testThatAllGeneratedSyntheticDNumbersAreValid() {
-		for (Fodselsnummer fnr : FodselsnummerCalculator.getManySynteticDNumberFodselsnummerForDate(date)) {
+		for (Fodselsnummer fnr : FodselsnummerCalculator.getManySyntheticDNumberFodselsnummerForDate(date)) {
 			assertTrue(FodselsnummerValidator.isValid(fnr.toString()), "Ugyldig fødselsnummer: " + fnr);
 		}
 	}
 
 	@Test
-	public void testThatAtLeastOneSynteticNumberIsGenerated() {
-		assertTrue(FodselsnummerCalculator.getManySynteticFodselsnummerForDate(date).size() >= 1);
+	public void testThatAtLeastOneSyntheticNumberIsGenerated() {
+		assertTrue(FodselsnummerCalculator.getManySyntheticFodselsnummerForDate(date).size() >= 1);
 	}
 
 	@Test
-	public void testThatAtLeastOneSynteticDNumberIsGenerated() {
-		assertTrue(FodselsnummerCalculator.getManySynteticDNumberFodselsnummerForDate(date).size() >= 1);
+	public void testThatAtLeastOneSyntheticDNumberIsGenerated() {
+		assertTrue(FodselsnummerCalculator.getManySyntheticDNumberFodselsnummerForDate(date).size() >= 1);
 	}
 }

--- a/src/test/java/no/bekk/bekkopen/person/SyntheticFodselsnummerValidatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/SyntheticFodselsnummerValidatorTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SyntheticFodselsnummerValidatorTest {
@@ -45,12 +46,15 @@ public class SyntheticFodselsnummerValidatorTest {
   }
 
   @Test
-  public void testSynteticDNumberIsValid() {
+  public void testSyntheticDNumberIsValid() {
     assertTrue(FodselsnummerValidator.isValid("49860699787"));
+    assertTrue(FodselsnummerValidator.isValid("49910690514"));
+    assertTrue(FodselsnummerValidator.isValid("49710697182"));
+    assertTrue(FodselsnummerValidator.isValid("49680699185"));
   }
 
   @Test
-  void testSynteticDNumberIsValidUtvidelse2021() {
+  void testSyntheticDNumberIsValidUtvidelse2021() {
 		assertTrue(FodselsnummerValidator.isValid("41814061033"));
 		assertTrue(FodselsnummerValidator.isValid("41814065640"));
 		assertTrue(FodselsnummerValidator.isValid("41814075603"));
@@ -58,5 +62,22 @@ public class SyntheticFodselsnummerValidatorTest {
 		assertTrue(FodselsnummerValidator.isValid("41810021827"));
 		assertTrue(FodselsnummerValidator.isValid("41810025091"));
 		assertTrue(FodselsnummerValidator.isValid("41810034422"));
+  }
+
+  @Test
+  void testSyntheticDNumberIsWithinValidRange() {
+	  //+80 (81-92)
+	  assertTrue(FodselsnummerValidator.isValid("41814061033"));
+	  assertFalse(FodselsnummerValidator.isValid("41804061033"));
+
+	  assertTrue(FodselsnummerValidator.isValid("41924061586"));
+	  assertFalse(FodselsnummerValidator.isValid("41934063587"));
+
+	  //+65 (66-77)
+	  assertTrue(FodselsnummerValidator.isValid("41664061188"));
+	  assertFalse(FodselsnummerValidator.isValid("41654061783"));
+
+	  assertTrue(FodselsnummerValidator.isValid("41774061388"));
+	  assertFalse(FodselsnummerValidator.isValid("41784061882"));
   }
 }


### PR DESCRIPTION

Har åpnet for bruk av testidenter med +65 fra Norsk Helsenett.
Strammet inn validering av testidenter med +80; hvor det tildligere ble godkjent som testident med 8 eller 9 i tredje siffer i ident er det nå kun godkjent med 81-92 og 66-77 i tredje og fjerde siffer.

Rettet noen skrivefeil.

NB: Har ikke laget mulighet for å opprette nye testidenter med +65 i denne versjonen, da det holder for oss å generere egne med +80.

PS: Jeg har valgt å legge det under samme flagg (se FodselsnummerValidator - l.73). Det kan evt. bli skilt ut i et flagg for testidenter fra norsk helsenett(+65) og et for skatteetaten(+80.