### PR TITLE
Deprecate Kjønn og fødselsår fra Fodselsnummer for fjerning

### DIFF
--- a/src/main/java/no/bekk/bekkopen/person/Fodselsnummer.java
+++ b/src/main/java/no/bekk/bekkopen/person/Fodselsnummer.java
@@ -73,12 +73,30 @@ public class Fodselsnummer extends StringNumber {
 	/**
 	 * Returns the birthyear of the Fodselsnummer
 	 *
-	 * @return A String containing the year of birth.
+	 * @return a String containg the year of birth represented by 2 (two) digits. Century is not included.
 	 */
+	public String getYear() {
+		return get2DigitBirthYear();
+	}
+
+	/**
+	 * Returns the birthyear of the Fodselsnummer
+	 *
+	 * @return A String containing the year of birth represented by 4 (four) digits. Century is included.
+	 * @deprecated For removal - After 1.1.2032 we cannot reliably conclude correct century anymore.
+	 * <a href="https://skatteetaten.github.io/folkeregisteret-api-dokumentasjon/nytt-fodselsnummer-fra-2032/">Nytt fødselsnummer fra 2032</a>
+	 * replaced by {@link #getYear()}
+	 */
+	@Deprecated
 	public String getBirthYear() {
 		return getCentury() + get2DigitBirthYear();
 	}
 
+	/**
+     * @deprecated For removal - After 1.1.2032 we cannot reliably conclude correct century anymore.
+     * 	<a href="https://skatteetaten.github.io/folkeregisteret-api-dokumentasjon/nytt-fodselsnummer-fra-2032/">Nytt fødselsnummer fra 2032</a>
+	 */
+	@Deprecated
 	String getCentury() {
 		String result = null;
 		int individnummerInt = Integer.parseInt(getIndividnummer());
@@ -152,9 +170,12 @@ public class Fodselsnummer extends StringNumber {
 
 	/**
 	 * Returns the digit that decides the gender - the 9th in the Fodselsnummer.
-	 *
+	 * 
+	 * @deprecated For removal - Gender will stop working after 1.1.2032
+     * 	<a href="https://skatteetaten.github.io/folkeregisteret-api-dokumentasjon/nytt-fodselsnummer-fra-2032/">Nytt fødselsnummer fra 2032</a>
 	 * @return The digit.
 	 */
+	@Deprecated
 	public int getGenderDigit() {
 		return getAt(8);
 	}
@@ -179,18 +200,24 @@ public class Fodselsnummer extends StringNumber {
 
 	/**
 	 * Returns true if the Fodselsnummer represents a man.
-	 *
+	 * 
+	 * @deprecated For removal - Gender will stop working after 1.1.2032
+     * 	<a href="https://skatteetaten.github.io/folkeregisteret-api-dokumentasjon/nytt-fodselsnummer-fra-2032/">Nytt fødselsnummer fra 2032</a>
 	 * @return true or false.
 	 */
+	@Deprecated
 	public boolean isMale() {
 		return getGenderDigit() % 2 != 0;
 	}
 
 	/**
 	 * Returns true if the Fodselsnummer represents a woman.
-	 *
+	 * 
+	 * @deprecated For removal - Gender will stop working after 1.1.2032
+     * 	<a href="https://skatteetaten.github.io/folkeregisteret-api-dokumentasjon/nytt-fodselsnummer-fra-2032/">Nytt fødselsnummer fra 2032</a>
 	 * @return true or false.
 	 */
+	@Deprecated
 	public boolean isFemale() {
 		return !isMale();
 	}
@@ -264,6 +291,11 @@ public class Fodselsnummer extends StringNumber {
 		return Integer.parseInt(fodselsnummer.substring(2, 3));
 	}
 
+	/**
+	 * @deprecated For removal - Gender will stop working after 1.1.2032
+     * 	<a href="https://skatteetaten.github.io/folkeregisteret-api-dokumentasjon/nytt-fodselsnummer-fra-2032/">Nytt fødselsnummer fra 2032</a>
+	 */
+	@Deprecated
 	public KJONN getKjonn() {
 		if (isFemale()) {
 			return KJONN.KVINNE;

--- a/src/main/java/no/bekk/bekkopen/person/FodselsnummerCalculator.java
+++ b/src/main/java/no/bekk/bekkopen/person/FodselsnummerCalculator.java
@@ -47,11 +47,14 @@ public class FodselsnummerCalculator {
   /**
    * Returns a List with valid Fodselsnummer instances for a given Date and gender.
    *
+   * @deprecated For removal - Gender will stop working after 1.1.2032
+   * 	<a href="https://skatteetaten.github.io/folkeregisteret-api-dokumentasjon/nytt-fodselsnummer-fra-2032/">Nytt fødselsnummer fra 2032</a>
+   *
    * @param date en dato
    * @param kjonn kjønn
    * @return liste med fødselsnummer
    */
-
+	@Deprecated
 	public static List<Fodselsnummer> getFodselsnummerForDateAndGender(Date date, KJONN kjonn) {
 		List<Fodselsnummer> result = getManyFodselsnummerForDate(date);
 		splitByGender(kjonn, result);

--- a/src/main/java/no/bekk/bekkopen/person/KJONN.java
+++ b/src/main/java/no/bekk/bekkopen/person/KJONN.java
@@ -26,6 +26,11 @@ package no.bekk.bekkopen.person;
  * #L%
  */
 
+/**
+ * @deprecated For removal - Gender will stop working after 1.1.2032
+ * <a href="https://skatteetaten.github.io/folkeregisteret-api-dokumentasjon/nytt-fodselsnummer-fra-2032/">Nytt fødselsnummer fra 2032</a>
+ */
+@Deprecated
 public enum KJONN {
 
 	MANN, KVINNE, BEGGE;


### PR DESCRIPTION
Fra 1.1.2032 vil nye fødselsnummer være kjønnsnøytrale. Vi kommer derfor til å fjerne kjønn fra Fodselsnummer.

Fra 1.1.2032 vil nye fødselsnummer tildeles etter ny algoritme. Tildeling av nummere vil starte fra 999 og telle nedover. Individnummerene vil derfor ikke lenger med sikkerhet kunne brukes til å si noe om århundre og derfor ikke alder.

Mer info fra Skatteetaten:
https://skatteetaten.github.io/folkeregisteret-api-dokumentasjon/nytt-fodselsnummer-fra-2032/