### PR TITLE
Skriv om no.bekk.bekkopen.person til å bruke java.time

### DIFF
--- a/src/main/java/no/bekk/bekkopen/person/FodselsnummerCalculator.java
+++ b/src/main/java/no/bekk/bekkopen/person/FodselsnummerCalculator.java
@@ -26,12 +26,10 @@ package no.bekk.bekkopen.person;
  * #L%
  */
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
@@ -51,8 +49,7 @@ public class FodselsnummerCalculator {
    * @param kjonn kjønn
    * @return liste med fødselsnummer
    */
-
-	public static List<Fodselsnummer> getFodselsnummerForDateAndGender(Date date, KJONN kjonn) {
+	public static List<Fodselsnummer> getFodselsnummerForDateAndGender(LocalDate date, KJONN kjonn) {
 		List<Fodselsnummer> result = getManyFodselsnummerForDate(date);
 		splitByGender(kjonn, result);
 		return result;
@@ -63,7 +60,7 @@ public class FodselsnummerCalculator {
    * @param date en dato
    * @return et fødselsnummer
    */
-	public static Fodselsnummer getFodselsnummerForDate(Date date){
+	public static Fodselsnummer getFodselsnummerForDate(LocalDate date) {
 		List<Fodselsnummer> fodselsnummerList = getManyFodselsnummerForDate(date);
 		Collections.shuffle(fodselsnummerList);
 		return fodselsnummerList.get(0);
@@ -75,14 +72,13 @@ public class FodselsnummerCalculator {
 	 * @param date The Date instance
 	 * @return A List with Fodelsnummer instances
 	 */
-
-	public static List<Fodselsnummer> getManyDNumberFodselsnummerForDate(Date date) {
+	public static List<Fodselsnummer> getManyDNumberFodselsnummerForDate(LocalDate date) {
 		if (date == null) {
 			throw new IllegalArgumentException();
 		}
-		DateFormat df = new SimpleDateFormat("ddMMyy");
+		DateTimeFormatter dtf = DateTimeFormatter.ofPattern("ddMMyy");
 		String centuryString = getCentury(date);
-		String dateString = df.format(date);
+		String dateString = dtf.format(date);
 		dateString = Character.toChars(dateString.charAt(0) + 4)[0] +
       dateString.substring(1);
 		return generateFodselsnummerForDate(dateString, centuryString);
@@ -94,14 +90,13 @@ public class FodselsnummerCalculator {
 	 * @param date The Date instance
 	 * @return A List with Fodelsnummer instances
 	 */
-
-	public static List<Fodselsnummer> getManySyntheticFodselsnummerForDate(Date date) {
+	public static List<Fodselsnummer> getManySyntheticFodselsnummerForDate(LocalDate date) {
 		if (date == null) {
 			throw new IllegalArgumentException();
 		}
-		DateFormat df = new SimpleDateFormat("ddMMyy");
+		DateTimeFormatter dtf = DateTimeFormatter.ofPattern("ddMMyy");
 		String centuryString = getCentury(date);
-		String dateString = df.format(date);
+		String dateString = dtf.format(date);
 		dateString = dateString.substring(0, 2) +
       Character.toChars(dateString.charAt(2) + 8)[0] +
       dateString.substring(3);
@@ -114,14 +109,13 @@ public class FodselsnummerCalculator {
 	 * @param date The Date instance
 	 * @return A List with Fodelsnummer instances
 	 */
-
-	public static List<Fodselsnummer> getManySyntheticDNumberFodselsnummerForDate(Date date) {
+	public static List<Fodselsnummer> getManySyntheticDNumberFodselsnummerForDate(LocalDate date) {
 		if (date == null) {
 			throw new IllegalArgumentException();
 		}
-		DateFormat df = new SimpleDateFormat("ddMMyy");
+		DateTimeFormatter dtf = DateTimeFormatter.ofPattern("ddMMyy");
 		String centuryString = getCentury(date);
-		String dateString = df.format(date);
+		String dateString = dtf.format(date);
 		dateString = Character.toChars(dateString.charAt(0) + 4)[0] +
       dateString.substring(1, 2) +
       Character.toChars(dateString.charAt(2) + 8)[0] +
@@ -135,14 +129,13 @@ public class FodselsnummerCalculator {
 	 * @param date The Date instance
 	 * @return A List with Fodelsnummer instances
 	 */
-
-	public static List<Fodselsnummer> getManyFodselsnummerForDate(Date date) {
+	public static List<Fodselsnummer> getManyFodselsnummerForDate(LocalDate date) {
 		if (date == null) {
 			throw new IllegalArgumentException();
 		}
-		DateFormat df = new SimpleDateFormat("ddMMyy");
+		DateTimeFormatter dtf = DateTimeFormatter.ofPattern("ddMMyy");
 		String centuryString = getCentury(date);
-		String dateString = df.format(date);
+		String dateString = dtf.format(date);
 		return generateFodselsnummerForDate(dateString, centuryString);
 	}
 
@@ -175,11 +168,8 @@ public class FodselsnummerCalculator {
 		return result;
 	}
 
-	private static String getCentury(Date date) {
-		Calendar c = Calendar.getInstance();
-		c.setTime(date);
-		int year = c.get(Calendar.YEAR);
-		return Integer.toString(year).substring(0, 2);
+	private static String getCentury(LocalDate date) {
+		return Integer.toString(date.getYear()).substring(0, 2);
 	}
 
 	private static void splitByGender(KJONN kjonn, List<Fodselsnummer> result) {

--- a/src/main/java/no/bekk/bekkopen/person/Person.java
+++ b/src/main/java/no/bekk/bekkopen/person/Person.java
@@ -26,14 +26,12 @@ package no.bekk.bekkopen.person;
  * #L%
  */
 
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 public class Person {
 
-	private final static DateFormat fDatoFormat = new SimpleDateFormat("ddMMyy");
+	private static final DateTimeFormatter fDatoFormat = DateTimeFormatter.ofPattern("ddMMyyyy");
 	private final Navn navn;
 	private final Fodselsnummer fodselsnummer;
 
@@ -67,8 +65,8 @@ public class Person {
 		return this.fodselsnummer.getDateOfBirth();
 	}
 
-	public Date getFodselsdato() throws ParseException {
-      return fDatoFormat.parse(this.fodselsnummer.getDateOfBirth());
+	public LocalDate getFodselsdato() {
+        return LocalDate.parse(this.fodselsnummer.getDateAndMonth() + this.fodselsnummer.getBirthYear(), fDatoFormat);
 	}
 
 	public String getPersonnummer() {

--- a/src/test/java/no/bekk/bekkopen/person/FodselsnummerCalculatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/FodselsnummerCalculatorTest.java
@@ -26,13 +26,12 @@ package no.bekk.bekkopen.person;
  * #L%
  */
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.text.DateFormat;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -41,14 +40,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FodselsnummerCalculatorTest {
 
-	private DateFormat df = null;
-	private Date date = null;
-
-	@BeforeEach
-	public void setUpDate() throws Exception {
-		df   = new SimpleDateFormat("ddMMyyyy");
-		date = df.parse("09062006");
-	}
+	private final DateTimeFormatter dtf = DateTimeFormatter.ofPattern("ddMMyyyy");
+	private LocalDate date = LocalDate.of(2006, Month.JUNE, 9);
 
 	@Test
 	public void testGetFodselsnummerForDate() {
@@ -87,9 +80,9 @@ public class FodselsnummerCalculatorTest {
 	}
 
 	@Test
-	public void testThatAtLeastOneDNumberIsGeneratedsas() throws ParseException {
-		assertEquals(82, FodselsnummerCalculator.getManyDNumberFodselsnummerForDate(df.parse("06061878")).size());
-		assertEquals(164, FodselsnummerCalculator.getManyDNumberFodselsnummerForDate(df.parse("12101921")).size());
+	public void testThatAtLeastOneDNumberIsGeneratedsas() {
+		assertEquals(82, FodselsnummerCalculator.getManyDNumberFodselsnummerForDate(LocalDate.parse("06061878", dtf)).size());
+		assertEquals(164, FodselsnummerCalculator.getManyDNumberFodselsnummerForDate(LocalDate.parse("12101921", dtf)).size());
 	}
 
 	@Test
@@ -107,22 +100,22 @@ public class FodselsnummerCalculatorTest {
 	}
 
 	@Test
-	public void testInvalidDateTooEarly() throws ParseException {
-		date = df.parse("09091853");
+	public void testInvalidDateTooEarly() {
+		date = LocalDate.parse("09091853", dtf);
 		List<Fodselsnummer> options = FodselsnummerCalculator.getManyFodselsnummerForDate(date);
 		assertEquals(0, options.size());
 	}
 
 	@Test
-	public void testInvalidDateTooLate() throws ParseException {
-		date = df.parse("09092040");
+	public void testInvalidDateTooLate() {
+		date = LocalDate.parse("09092040", dtf);
 		List<Fodselsnummer> options = FodselsnummerCalculator.getManyFodselsnummerForDate(date);
 		assertEquals(0, options.size());
 	}
 
 	@Test
 	public void testOneFodselsnummer() throws ParseException {
-		date = df.parse("01121980");
+		date = LocalDate.parse("01121980", dtf);
 		Fodselsnummer fodselsnummer = FodselsnummerCalculator.getFodselsnummerForDate(date);
 		assertTrue(FodselsnummerValidator.isValid(fodselsnummer.toString()));
 	}

--- a/src/test/java/no/bekk/bekkopen/person/PersonTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/PersonTest.java
@@ -26,15 +26,12 @@ package no.bekk.bekkopen.person;
  * #L%
  */
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.util.Calendar;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -43,17 +40,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PersonTest {
 
-	private Calendar kalender;
-
-	@BeforeEach
-	public void initialiserKalender() {
-		kalender = Calendar.getInstance();
-	}
-
 	@Test
-	public void lagMann() throws ParseException {
-		kalender.set(1973, Calendar.DECEMBER, 10);
-		Date fodselsdato = kalender.getTime();
+	public void lagMann() {
+		LocalDate fodselsdato = LocalDate.of(1973, Month.DECEMBER, 10);
 		List<Fodselsnummer> fodselsnumre = FodselsnummerCalculator.getFodselsnummerForDateAndGender(fodselsdato,
 				KJONN.MANN);
 		Fodselsnummer fodselsnummer = fodselsnumre.get(0);
@@ -80,9 +69,9 @@ public class PersonTest {
 		Navn pNavn = person.getNavn();
 		NavnGeneratorTest.assertGyldigNavn(pNavn);
 
-		Date pFodselsdato = person.getFodselsdato();
-		DateFormat df = DateFormat.getDateInstance(DateFormat.SHORT, new Locale("no", "NO"));
-		assertEquals(df.format(fodselsdato), df.format(pFodselsdato));
+		LocalDate pFodselsdato = person.getFodselsdato();
+		DateTimeFormatter dtf = DateTimeFormatter.ofPattern("dd.MM.yyyy");
+		assertEquals(dtf.format(fodselsdato), dtf.format(pFodselsdato));
 
 		String pFodselsdatoString = person.getFodselsdatoAsString();
 		assertEquals("101273", pFodselsdatoString);

--- a/src/test/java/no/bekk/bekkopen/person/SyntheticFodselsnummerCalculatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/SyntheticFodselsnummerCalculatorTest.java
@@ -28,18 +28,16 @@ package no.bekk.bekkopen.person;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.Month;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SyntheticFodselsnummerCalculatorTest {
 
-	private Date date = null;
+	private LocalDate date = LocalDate.of(2006, Month.JUNE, 9);
 
 	@BeforeAll
 	public static void setup() {
@@ -49,12 +47,6 @@ public class SyntheticFodselsnummerCalculatorTest {
 	@AfterAll
 	public static void teardown() {
 		FodselsnummerValidator.ALLOW_SYNTHETIC_NUMBERS = false;
-	}
-
-	@BeforeEach
-	public void setUpDate() throws Exception {
-		DateFormat df = new SimpleDateFormat("ddMMyyyy");
-		date = df.parse("09062006");
 	}
 
 	@Test

--- a/src/test/java/no/bekk/bekkopen/person/annotation/FodselsnummerAnnotationTest.java
+++ b/src/test/java/no/bekk/bekkopen/person/annotation/FodselsnummerAnnotationTest.java
@@ -34,7 +34,8 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
-import java.util.Date;
+
+import java.time.LocalDate;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -69,7 +70,7 @@ public class FodselsnummerAnnotationTest {
 
     @Test
     public void should_validate_valid_fodselsnummer(){
-        Person k = new Person(FodselsnummerCalculator.getFodselsnummerForDate(new Date()).toString());
+        Person k = new Person(FodselsnummerCalculator.getFodselsnummerForDate(LocalDate.now()).toString());
 
         Set<ConstraintViolation<Person>> violations = validator.validate(k);
 


### PR DESCRIPTION
Breaking change: Du må erstatte java.util.Date med java.time.LocalDate.

Gjorde i tillegg en liten endring i Person::getFodselsDato slik at LocalDate-en som returneres har riktig århundre. Beregning av fødselsdato fra fødselsnummer blir riktignok deprecated i https://github.com/bekkopen/NoCommons/pull/74, men metoden får vel leve en liten stund til.