### PR TITLE
Fix KidnummerValidator incorrectly accepting invalid KID numbers

### DIFF
--- a/src/main/java/no/bekk/bekkopen/banking/KidnummerValidator.java
+++ b/src/main/java/no/bekk/bekkopen/banking/KidnummerValidator.java
@@ -92,7 +92,8 @@ public class KidnummerValidator extends StringNumberValidator implements Constra
             return;
         }
         String kMod11 = calculateMod11CheckSumAllowDash(getMod11Weights(k), k);
-        if ("-".equals(kMod11) || Integer.parseInt(kMod11) == k.getChecksumDigit()) {
+        String lastChar = kidnummer.substring(kidnummer.length() - 1);
+        if (kMod11.equals(lastChar)) {
             return;
         }
         throw new IllegalArgumentException(ERROR_INVALID_CHECKSUM + kidnummer);

--- a/src/test/java/no/bekk/bekkopen/banking/KidnummerValidatorTest.java
+++ b/src/test/java/no/bekk/bekkopen/banking/KidnummerValidatorTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.Test;
 import static no.bekk.bekkopen.common.Checksums.ERROR_INVALID_CHECKSUM;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -42,6 +41,7 @@ public class KidnummerValidatorTest {
     private static final String KIDNUMMER_VALID_MOD10 = "2345676";
     private static final String KIDNUMMER_VALID_MOD11 = "12345678903";
     private static final String KIDNUMMER_INVALID_CHECKSUM = "2345674";
+    private static final String KIDNUMMER_INVALID_CHECKSUM_MOD10_AND_MOD11 = "100030";
     private static final String KIDNUMMER_INVALID_LENGTH_SHORT = "122";
     private static final String KIDNUMMER_INVALID_LENGTH_LONG = "12345678901234567890123456";
     private static final String KIDNUMMER_VALID_WITH_DASH = "1000005-";
@@ -83,9 +83,7 @@ public class KidnummerValidatorTest {
 
     @Test
     public void testValidKidnummerMod10ButUnableToCalculateMod11() {
-        boolean result = KidnummerValidator.isValid("01290865");
-
-        assertEquals(true, result);
+        assertTrue(KidnummerValidator.isValid("01290865"));
     }
 
     @Test
@@ -108,4 +106,8 @@ public class KidnummerValidatorTest {
         assertTrue(KidnummerValidator.isValid(KIDNUMMER_VALID_WITH_DASH));
     }
 
+    @Test
+    public void testInvalidKidnummerFailingBothMod10AndMod11() {
+        assertFalse(KidnummerValidator.isValid(KIDNUMMER_INVALID_CHECKSUM_MOD10_AND_MOD11));
+    }
 }


### PR DESCRIPTION
Fixes a bug in `KidnummerValidator.isValid()` where some invalid KID numbers were accepted.

Examples:
- 100030
- 100031
- 100033

The issue is in the mod11 check:
```java
if ("-".equals(kMod11) || Integer.parseInt(kMod11) == k.getChecksumDigit()) {
    return; // valid
}
```
When the mod11 remainder is 1, there is no valid single digit that can serve as a checksum digit, so it returns `-` instead. The bug was that the validator treated this as an automatic pass, without checking that the KID number actually ended with `-`. As a result, any KID that failed mod10 and happened to produce a mod11 remainder of 1 would be incorrectly accepted.

The fix is to compare the calculated mod11 result directly with the last character of the KID:
```java
String lastChar = kidnummer.substring(kidnummer.length() - 1);
if (kMod11.equals(lastChar)) {
    return; // valid
}
```
This works for both digits and `-` without special handling.
`1000005-` still passes because mod11 returns `-` and the last character is `-`, while `100030` now correctly fails because mod11 returns `-` but the last character is `0`.

Also added a test for the bug case:
```java
private static final String KIDNUMMER_INVALID_CHECKSUM_MOD10_AND_MOD11 = "100030";

@Test
public void testInvalidKidnummerFailingBothMod10AndMod11() {
    assertFalse(KidnummerValidator.isValid(KIDNUMMER_INVALID_CHECKSUM_MOD10_AND_MOD11));
}
```